### PR TITLE
docs: Redesign demo site with modern UI and no-scroll player layouts

### DIFF
--- a/docs/demo1.html
+++ b/docs/demo1.html
@@ -1,120 +1,359 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Etude: A Music Transcription and Generation Model Showcase</title>
+    <title>Etude — Model Comparison</title>
+
+    <script>
+      (function () {
+        if (localStorage.getItem("etude-theme") === "dark") document.documentElement.classList.add("dark");
+      })();
+    </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ["Inter", "Noto Sans TC", "ui-sans-serif", "system-ui"],
+              display: ["Space Grotesk", "Inter", "ui-sans-serif", "system-ui"],
+              mono: ["JetBrains Mono", "ui-monospace", "monospace"],
+            },
+            colors: {
+              brand: { 300: "#a5b4fc", 500: "#6366f1", 600: "#4f46e5", 700: "#4338ca" },
+              accent: { 500: "#14b8a6", 600: "#0d9488" },
+            },
+          },
+        },
+      };
+    </script>
+
     <script src="https://cdn.jsdelivr.net/combine/npm/tone@14.7.58,npm/@magenta/music@1.23.1/es6/core.js,npm/focus-visible@5,npm/html-midi-player@1.5.0"></script>
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500&family=Noto+Sans+TC:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
 
     <style>
-      body {
-        font-family: "Inter", "Noto Sans TC", sans-serif;
+      :root { color-scheme: light dark; }
+      html, body { height: 100%; }
+      body { overflow: hidden; } /* desktop: no scroll */
+      @media (max-width: 1023px) {
+        body { overflow: auto; } /* mobile fallback */
       }
-      #bottom-player {
-        transition: transform 0.3s ease-in-out;
+
+      .nav-link { position: relative; transition: color 0.2s; }
+      .nav-link::after {
+        content: "";
+        position: absolute;
+        left: 12%; right: 12%; bottom: -1px;
+        height: 2px;
+        background: linear-gradient(90deg, #6366f1, #14b8a6);
+        border-radius: 2px;
+        transform: scaleX(0);
+        transform-origin: center;
+        transition: transform 0.25s ease;
       }
-      .nav-link {
-        transition: color 0.2s, border-color 0.2s;
-      }
-      .nav-link.active {
-        color: #4f46e5; /* indigo-600 */
-        border-bottom-color: #4f46e5;
-      }
+      .nav-link.active { color: #4f46e5; }
+      .dark .nav-link.active { color: #a5b4fc; }
+      .nav-link.active::after { transform: scaleX(1); }
+
+      /* Player skin */
       #player::part(control-panel) {
-        background: #f3f4f6;
-        border: 1px solid #e5e7eb;
+        background: transparent;
+        border: none;
         border-radius: 12px;
+        padding: 2px 4px;
       }
-      #player::part(play-button) {
-        color: #4f46e5;
-      }
+      #player::part(play-button) { color: #4f46e5; }
+      .dark #player::part(play-button) { color: #a5b4fc; }
+      #player::part(time) { font-family: "JetBrains Mono", monospace; font-size: 0.75rem; }
       #visualizer {
-        border-radius: 8px;
-        border: 1px solid #e5e7eb;
+        border-radius: 10px;
+        border: 1px solid rgb(226 232 240);
+        background: #fff;
+        width: 100%;
+        height: 100%;
       }
-      /* Hide inactive category content */
-      .category-content:not(.active) {
-        display: none;
+      .dark #visualizer {
+        border-color: rgb(30 41 59);
+        background: #0b1220;
+      }
+
+      /* Track button */
+      .track-btn {
+        transition: background-color 0.15s, border-color 0.15s, transform 0.1s;
+      }
+      .track-btn:hover {
+        background-color: rgb(238 242 255);
+        border-color: rgb(165 180 252);
+      }
+      .dark .track-btn:hover {
+        background-color: rgb(30 41 59);
+        border-color: rgb(99 102 241);
+      }
+      .track-btn.playing {
+        background: linear-gradient(90deg, rgba(99,102,241,0.12), rgba(20,184,166,0.12));
+        border-color: rgb(99 102 241);
+      }
+      .dark .track-btn.playing {
+        background: linear-gradient(90deg, rgba(99,102,241,0.2), rgba(20,184,166,0.2));
+        border-color: rgb(165 180 252);
+      }
+
+      /* Chip */
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.06rem 0.45rem;
+        border-radius: 9999px;
+        font-family: "JetBrains Mono", monospace;
+        font-size: 0.65rem;
+        line-height: 1rem;
+      }
+      .chip-ours {
+        background: linear-gradient(90deg, rgba(99,102,241,0.12), rgba(20,184,166,0.12));
+        color: #4338ca;
+      }
+      .dark .chip-ours { color: #a5b4fc; }
+      .chip-ref {
+        background: rgb(241 245 249);
+        color: rgb(71 85 105);
+      }
+      .dark .chip-ref {
+        background: rgb(30 41 59);
+        color: rgb(148 163 184);
+      }
+      .chip-base {
+        background: rgb(248 250 252);
+        color: rgb(100 116 139);
+      }
+      .dark .chip-base {
+        background: rgb(15 23 42);
+        color: rgb(100 116 139);
+      }
+
+      /* Nav arrow */
+      .nav-arrow {
+        transition: background-color 0.2s, border-color 0.2s, transform 0.15s;
+      }
+      .nav-arrow:hover:not(:disabled) {
+        background: linear-gradient(135deg, #6366f1, #14b8a6);
+        color: white;
+        border-color: transparent;
+        transform: scale(1.05);
+      }
+      .nav-arrow:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+
+      /* Slide transition */
+      .song-view {
+        animation: slide-in 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
+      }
+      @keyframes slide-in {
+        from { opacity: 0; transform: translateY(6px); }
+        to { opacity: 1; transform: none; }
+      }
+      .song-view.leaving-left {
+        animation: slide-out-left 0.18s ease-in both;
+      }
+      .song-view.leaving-right {
+        animation: slide-out-right 0.18s ease-in both;
+      }
+      @keyframes slide-out-left {
+        to { opacity: 0; transform: translateX(-24px); }
+      }
+      @keyframes slide-out-right {
+        to { opacity: 0; transform: translateX(24px); }
+      }
+
+      /* Progress bar for song index */
+      .song-progress {
+        height: 3px;
+        background: rgb(226 232 240);
+        border-radius: 999px;
+        overflow: hidden;
+      }
+      .dark .song-progress {
+        background: rgb(30 41 59);
+      }
+      .song-progress-fill {
+        height: 100%;
+        background: linear-gradient(90deg, #6366f1, #14b8a6);
+        transition: width 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+      }
+
+      /* Keyboard hint */
+      kbd {
+        font-family: "JetBrains Mono", monospace;
+        font-size: 0.7rem;
+        padding: 0.1rem 0.4rem;
+        border-radius: 4px;
+        background: rgb(241 245 249);
+        border: 1px solid rgb(203 213 225);
+        border-bottom-width: 2px;
+        color: rgb(71 85 105);
+      }
+      .dark kbd {
+        background: rgb(30 41 59);
+        border-color: rgb(51 65 85);
+        color: rgb(203 213 225);
+      }
+
+      .aurora-sub {
+        background:
+          radial-gradient(50% 60% at 15% 0%, rgba(99, 102, 241, 0.12), transparent 60%),
+          radial-gradient(40% 50% at 90% 10%, rgba(20, 184, 166, 0.1), transparent 60%);
+      }
+      .dark .aurora-sub {
+        background:
+          radial-gradient(50% 60% at 15% 0%, rgba(99, 102, 241, 0.2), transparent 60%),
+          radial-gradient(40% 50% at 90% 10%, rgba(20, 184, 166, 0.15), transparent 60%);
       }
     </style>
   </head>
-  <body class="bg-gray-100 text-gray-800">
-    <!-- Header Section -->
-    <header class="text-center py-8 md:py-12 bg-white border-b border-gray-200">
-      <div class="container mx-auto px-4 relative">
-        <a
-          href="index.html"
-          class="absolute top-4 left-4 md:top-1/2 md:-translate-y-1/2 md:left-8 inline-flex items-center text-gray-500 hover:text-indigo-600 transition-colors"
-        >
-          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
-          </svg>
+
+  <body class="font-sans bg-slate-50 text-slate-800 dark:bg-slate-950 dark:text-slate-200 antialiased selection:bg-brand-600/25 flex flex-col">
+    <!-- Top bar -->
+    <div class="flex-none backdrop-blur bg-white/70 dark:bg-slate-950/70 border-b border-slate-200/60 dark:border-slate-800/60">
+      <div class="container mx-auto px-4 h-12 flex items-center justify-between">
+        <a href="index.html" class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 dark:text-slate-300 hover:text-brand-700 dark:hover:text-brand-300 transition">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
           Back
         </a>
-        <h1 class="text-3xl md:text-4xl font-bold text-gray-900">Model Comparison Showcase</h1>
-        <p class="mt-3 text-base md:text-md text-gray-600 max-w-3xl mx-auto">
-          Listen to and compare the outputs of our Etude model against other systems. Click any play button to start.
-        </p>
+        <a href="index.html" class="flex items-center gap-2 font-display font-semibold tracking-tight">
+          <span class="inline-grid place-items-center w-6 h-6 rounded-md bg-gradient-to-br from-brand-500 to-accent-500 text-white text-[10px]">E</span>
+          <span class="text-slate-900 dark:text-slate-100 text-sm">Etude</span>
+          <span class="hidden sm:inline text-xs font-mono font-normal text-slate-500 dark:text-slate-400">/ model comparison</span>
+        </a>
+        <button id="theme-toggle" type="button" aria-label="Toggle theme" class="grid place-items-center w-8 h-8 rounded-md border border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 transition">
+          <svg class="w-3.5 h-3.5 block dark:hidden" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+          <svg class="w-3.5 h-3.5 hidden dark:block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
       </div>
-    </header>
+    </div>
 
-    <!-- Sticky Navigation Tabs -->
-    <nav id="category-nav" class="sticky top-0 z-20 bg-white/90 backdrop-blur-sm shadow-sm">
-      <div class="container mx-auto flex justify-center space-x-4 md:space-x-8 border-b border-gray-200">
-        <!-- Nav links will be generated by JavaScript -->
+    <!-- Category tabs -->
+    <nav id="category-nav" class="flex-none bg-white/85 dark:bg-slate-950/85 border-b border-slate-200/60 dark:border-slate-800/60 relative overflow-hidden">
+      <div class="absolute inset-0 aurora-sub pointer-events-none"></div>
+      <div class="container mx-auto flex justify-center gap-1 md:gap-3 px-4 relative">
+        <!-- Injected -->
       </div>
     </nav>
 
-    <!-- Main Content: Song List -->
-    <main id="song-list-container" class="container mx-auto p-4 md:p-8">
-      <div id="loading-indicator" class="text-center py-20">
-        <p class="text-gray-500 text-lg">Loading demo songs...</p>
+    <!-- Main player -->
+    <main class="flex-1 min-h-0 overflow-hidden">
+      <div id="loading-indicator" class="h-full grid place-items-center">
+        <div class="inline-flex items-center gap-3 text-slate-500 dark:text-slate-400">
+          <svg class="w-5 h-5 animate-spin" viewBox="0 0 24 24" fill="none"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v3a5 5 0 00-5 5H4z"></path></svg>
+          <span>Loading demo songs…</span>
+        </div>
       </div>
-      <!-- Category content will be injected here -->
-    </main>
 
-    <!-- Sticky Bottom Player (Initially Hidden) -->
-    <div id="bottom-player" class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 shadow-2xl p-4 z-30 transform translate-y-full">
-      <div class="container mx-auto">
-        <div class="flex items-center mb-3">
-          <h3 id="now-playing-title" class="text-lg font-semibold text-gray-800 flex-grow truncate">playing...</h3>
-          <button id="close-player-btn" class="text-gray-500 hover:text-gray-800 transition-colors">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
+      <div id="player-shell" class="hidden h-full container mx-auto px-3 md:px-6 py-3 md:py-4">
+        <!-- Song header: title + navigation + progress -->
+        <div class="flex items-center gap-3 md:gap-4 mb-3">
+          <button id="prev-btn" type="button" aria-label="Previous song" class="nav-arrow flex-none grid place-items-center w-10 h-10 md:w-11 md:h-11 rounded-full border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-300">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
+          </button>
+
+          <div class="flex-1 min-w-0">
+            <div id="song-view" class="song-view">
+              <div class="flex items-baseline gap-2 flex-wrap">
+                <span id="song-category-badge" class="text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-brand-50 dark:bg-brand-600/10 text-brand-700 dark:text-brand-300">J-POP</span>
+                <span id="song-index" class="text-xs font-mono text-slate-500 dark:text-slate-400">01 / 25</span>
+              </div>
+              <h1 id="song-title" class="mt-0.5 font-display text-lg md:text-2xl font-bold text-slate-900 dark:text-white truncate">—</h1>
+            </div>
+            <div class="mt-2 song-progress">
+              <div id="song-progress-fill" class="song-progress-fill" style="width: 4%;"></div>
+            </div>
+          </div>
+
+          <button id="next-btn" type="button" aria-label="Next song" class="nav-arrow flex-none grid place-items-center w-10 h-10 md:w-11 md:h-11 rounded-full border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-300">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"/></svg>
           </button>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-center">
-          <div class="md:col-span-1">
-            <midi-player id="player" sound-font></midi-player>
-          </div>
-          <div class="md:col-span-2">
-            <midi-visualizer type="piano-roll" id="visualizer"></midi-visualizer>
-          </div>
-        </div>
+        <!-- Content grid: left tracks | right player -->
+        <div class="grid grid-cols-1 lg:grid-cols-5 gap-3 md:gap-4 flex-1 min-h-0" style="height: calc(100% - 72px);">
+          <!-- Left: Tracks -->
+          <section class="lg:col-span-2 flex flex-col gap-3 min-h-0">
+            <div class="flex-1 min-h-0 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-3 md:p-4 flex flex-col">
+              <div class="flex items-center justify-between mb-2">
+                <h2 class="font-display text-sm font-semibold text-slate-700 dark:text-slate-300">Tracks</h2>
+                <span class="text-[10px] font-mono text-slate-400 dark:text-slate-500">
+                  <kbd>1</kbd>–<kbd>7</kbd> to play
+                </span>
+              </div>
+              <div id="track-list" class="flex-1 min-h-0 overflow-y-auto pr-1 space-y-1.5">
+                <!-- Injected -->
+              </div>
+            </div>
 
-        <div class="text-center mt-2">
-          <p class="text-xs text-gray-400">
-            MIDI Player powered by
-            <a href="https://github.com/cifkao/html-midi-player" target="_blank" rel="noopener noreferrer" class="underline hover:text-gray-600">
-              html-midi-player
-            </a>
-            by Ondřej Cífka.
-          </p>
+            <!-- YouTube embed -->
+            <div class="flex-none bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl overflow-hidden">
+              <div id="yt-container" class="w-full aspect-video bg-black">
+                <!-- Injected -->
+              </div>
+            </div>
+          </section>
+
+          <!-- Right: Piano roll + player controls -->
+          <section class="lg:col-span-3 flex flex-col min-h-0">
+            <div class="flex-1 min-h-0 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-3 md:p-4 flex flex-col">
+              <div class="flex items-center justify-between mb-2">
+                <div class="flex items-center gap-2">
+                  <span class="flex items-center gap-1">
+                    <span class="inline-block w-1 h-3 rounded-sm bg-brand-500 animate-pulse"></span>
+                    <span class="inline-block w-1 h-4 rounded-sm bg-brand-400 animate-pulse [animation-delay:120ms]"></span>
+                    <span class="inline-block w-1 h-2.5 rounded-sm bg-accent-500 animate-pulse [animation-delay:240ms]"></span>
+                  </span>
+                  <div>
+                    <p class="text-[10px] uppercase font-mono tracking-wider text-slate-500 dark:text-slate-400">Now playing</p>
+                    <h3 id="now-playing-title" class="text-xs md:text-sm font-semibold text-slate-900 dark:text-slate-100 truncate max-w-[18rem] md:max-w-[28rem]">Select a track</h3>
+                  </div>
+                </div>
+                <span class="hidden sm:inline text-[10px] font-mono text-slate-400 dark:text-slate-500">
+                  <kbd>Space</kbd> play/pause
+                </span>
+              </div>
+
+              <div class="flex-1 min-h-0 rounded-lg overflow-hidden">
+                <midi-visualizer type="piano-roll" id="visualizer"></midi-visualizer>
+              </div>
+
+              <div class="mt-3 flex-none">
+                <midi-player id="player" sound-font></midi-player>
+              </div>
+            </div>
+          </section>
         </div>
+      </div>
+    </main>
+
+    <!-- Keyboard hint footer -->
+    <div class="flex-none hidden lg:block border-t border-slate-200/60 dark:border-slate-800/60 bg-white/70 dark:bg-slate-950/70 backdrop-blur">
+      <div class="container mx-auto px-4 py-1.5 flex items-center justify-center gap-4 text-[11px] text-slate-500 dark:text-slate-400">
+        <span><kbd>←</kbd> <kbd>→</kbd> song</span>
+        <span><kbd>[</kbd> <kbd>]</kbd> category</span>
+        <span><kbd>Space</kbd> play/pause</span>
+        <span><kbd>1</kbd>–<kbd>7</kbd> track</span>
+        <span class="hidden xl:inline">MIDI playback via <a href="https://github.com/cifkao/html-midi-player" target="_blank" rel="noopener noreferrer" class="underline hover:text-slate-700 dark:hover:text-slate-300">html-midi-player</a></span>
       </div>
     </div>
 
     <script>
       document.addEventListener("DOMContentLoaded", async function () {
-        // --- CONFIGURATION ---
         const config = {
           songCategories: {
             JPOP: { name: "J-POP", count: 25 },
@@ -123,219 +362,322 @@
             WESTERN: { name: "Western Pop", count: 25 },
           },
           midiFiles: [
-            { id: "human", name: "Human Performance", file: "human.mid" },
-            { id: "etude_d", name: "Etude Decoder (Ours)", file: "etude_d.mid" },
-            { id: "etude_d_d", name: "Etude Decoder - Default Style (Ours)", file: "etude_d_d.mid" },
-            { id: "etude_e", name: "Etude Extractor (Ours)", file: "etude_e.mid" },
-            { id: "music2midi", name: "Music2Midi", file: "music2midi.mid" },
-            { id: "picogen", name: "PiCoGen2", file: "picogen.mid" },
-            { id: "amtapc", name: "AMT-APC", file: "amtapc.mid" },
+            { id: "human", name: "Human Performance", file: "human.mid", tag: "ref" },
+            { id: "etude_d", name: "Etude Decoder", file: "etude_d.mid", tag: "ours" },
+            { id: "etude_d_d", name: "Etude Decoder — Default Style", file: "etude_d_d.mid", tag: "ours" },
+            { id: "etude_e", name: "Etude Extractor", file: "etude_e.mid", tag: "ours" },
+            { id: "music2midi", name: "Music2Midi", file: "music2midi.mid", tag: "baseline" },
+            { id: "picogen", name: "PiCoGen2", file: "picogen.mid", tag: "baseline" },
+            { id: "amtapc", name: "AMT-APC", file: "amtapc.mid", tag: "baseline" },
           ],
           metadataUrl: "./songs/metadata.json",
         };
 
-        // --- DOM ELEMENT REFERENCES ---
         const dom = {
           navContainer: document.querySelector("#category-nav .container"),
-          songListContainer: document.getElementById("song-list-container"),
-          bottomPlayer: document.getElementById("bottom-player"),
+          loadingIndicator: document.getElementById("loading-indicator"),
+          playerShell: document.getElementById("player-shell"),
           player: document.getElementById("player"),
           visualizer: document.getElementById("visualizer"),
           nowPlayingTitle: document.getElementById("now-playing-title"),
-          closePlayerBtn: document.getElementById("close-player-btn"),
-          loadingIndicator: document.getElementById("loading-indicator"),
+          themeToggle: document.getElementById("theme-toggle"),
+          prevBtn: document.getElementById("prev-btn"),
+          nextBtn: document.getElementById("next-btn"),
+          songView: document.getElementById("song-view"),
+          songCategoryBadge: document.getElementById("song-category-badge"),
+          songIndex: document.getElementById("song-index"),
+          songTitle: document.getElementById("song-title"),
+          songProgressFill: document.getElementById("song-progress-fill"),
+          trackList: document.getElementById("track-list"),
+          ytContainer: document.getElementById("yt-container"),
         };
 
-        // --- HELPER FUNCTIONS ---
+        dom.themeToggle.addEventListener("click", () => {
+          const root = document.documentElement;
+          root.classList.toggle("dark");
+          localStorage.setItem("etude-theme", root.classList.contains("dark") ? "dark" : "light");
+        });
+
         const utils = {
-          pad: (num) => num.toString().padStart(2, "0"),
+          pad: (n) => n.toString().padStart(2, "0"),
           getYoutubeEmbedUrl: (url) => {
             if (!url) return "";
-            let videoId = "";
             try {
-              const urlObj = new URL(url);
-              if (urlObj.hostname === "youtu.be") videoId = urlObj.pathname.slice(1);
-              else if (urlObj.hostname.includes("youtube.com")) videoId = urlObj.searchParams.get("v");
-            } catch (e) {
-              console.error("Invalid URL for YouTube embed:", url);
+              const u = new URL(url);
+              let id = "";
+              if (u.hostname === "youtu.be") id = u.pathname.slice(1);
+              else if (u.hostname.includes("youtube.com")) id = u.searchParams.get("v");
+              return id ? `https://www.youtube.com/embed/${id}` : "";
+            } catch {
               return "";
             }
-            return videoId ? `https://www.youtube.com/embed/${videoId}` : "";
           },
           fetchMetadata: async (url) => {
             try {
-              const response = await fetch(url);
-              if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-              const data = await response.json();
-              return data.reduce((map, item) => ({ ...map, [item.dir_name]: item }), {});
-            } catch (error) {
-              dom.loadingIndicator.textContent = "[ERROR] Can't load metadata.json.";
-              dom.loadingIndicator.classList.add("text-red-500");
+              const res = await fetch(url);
+              if (!res.ok) throw new Error(res.status);
+              const data = await res.json();
+              return data.reduce((m, it) => ({ ...m, [it.dir_name]: it }), {});
+            } catch {
+              dom.loadingIndicator.innerHTML = `<p class="text-red-500 dark:text-red-400">[ERROR] Could not load metadata.json.</p>`;
               return null;
             }
           },
+          tagClass: (tag) => (tag === "ours" ? "chip chip-ours" : tag === "ref" ? "chip chip-ref" : "chip chip-base"),
+          tagLabel: (tag) => (tag === "ours" ? "Ours" : tag === "ref" ? "Ref" : "Baseline"),
         };
 
-        // --- UI RENDERING ---
+        // ---- State ----
+        const state = {
+          categoryKeys: Object.keys(config.songCategories),
+          categoryIdx: 0,
+          songIdx: 0, // 0-indexed within category
+          metadata: null,
+          currentTrackId: null,
+        };
+
+        // ---- UI ----
         const ui = {
-          renderAll: (metadataMap) => {
-            dom.loadingIndicator.style.display = "none";
-
-            const categoryKeys = Object.keys(config.songCategories);
-            categoryKeys.forEach((key, index) => {
-              const category = config.songCategories[key];
-              ui.createNavLink(key, category.name, index === 0);
-              ui.createCategorySection(key, category, metadataMap, index === 0);
+          buildNav: () => {
+            state.categoryKeys.forEach((key, idx) => {
+              const a = document.createElement("a");
+              a.href = `#${key}`;
+              a.textContent = config.songCategories[key].name;
+              a.className = "nav-link py-2.5 px-3 md:px-4 text-sm font-medium text-slate-500 dark:text-slate-400 hover:text-brand-700 dark:hover:text-brand-300 cursor-pointer";
+              if (idx === 0) a.classList.add("active");
+              a.dataset.idx = idx;
+              a.addEventListener("click", (e) => {
+                e.preventDefault();
+                app.goToCategory(idx);
+              });
+              dom.navContainer.appendChild(a);
             });
           },
-          createNavLink: (key, name, isActive) => {
-            const navLink = document.createElement("a");
-            navLink.href = `#${key}`;
-            navLink.textContent = name;
-            navLink.className =
-              "nav-link py-3 px-2 md:px-4 text-sm md:text-base font-semibold text-gray-500 hover:text-indigo-600 border-b-2 border-transparent cursor-pointer";
-            if (isActive) navLink.classList.add("active");
-            navLink.dataset.target = key;
-            dom.navContainer.appendChild(navLink);
-          },
-          createCategorySection: (key, category, metadataMap, isActive) => {
-            const section = document.createElement("div");
-            section.id = `category-${key}`;
-            section.className = "category-content space-y-8";
-            if (isActive) section.classList.add("active");
-
-            for (let i = 1; i <= category.count; i++) {
-              const songId = `${key}${utils.pad(i)}`;
-              const songMeta = metadataMap[songId];
-              if (songMeta) section.appendChild(ui.createSongCard(songId, songMeta));
-            }
-            dom.songListContainer.appendChild(section);
-          },
-          createSongCard: (songId, songMeta) => {
-            const card = document.createElement("div");
-            card.className = "bg-white p-5 rounded-xl shadow-md overflow-hidden";
-
-            const cardTitle = document.createElement("h3");
-            cardTitle.className = "text-xl font-bold mb-4 text-gray-800";
-            cardTitle.textContent = songMeta.song_name || songId;
-            card.appendChild(cardTitle);
-
-            const cardGrid = document.createElement("div");
-            // MODIFIED: Changed items-center to items-start for better alignment
-            cardGrid.className = "grid grid-cols-1 md:grid-cols-2 gap-6 items-start";
-
-            // Left side: Track list
-            // MODIFIED: Changed from <ul> to a div with grid layout
-            const trackList = document.createElement("div");
-            trackList.className = "grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2";
-            config.midiFiles.forEach((midi) => {
-              const trackPath = `./songs/${songId}/${midi.file}`;
-              const trackName = `${songMeta.song_name} - ${midi.name}`;
-              trackList.appendChild(ui.createTrackListItem(midi, trackPath, trackName, songMeta));
+          updateNav: () => {
+            dom.navContainer.querySelectorAll(".nav-link").forEach((l) => {
+              l.classList.toggle("active", Number(l.dataset.idx) === state.categoryIdx);
             });
-            cardGrid.appendChild(trackList);
-
-            // Right side: YouTube embed
-            const embedContainer = document.createElement("div");
-            const embedUrl = utils.getYoutubeEmbedUrl(songMeta.song_url);
-            if (embedUrl) {
-              // MODIFIED: Replaced deprecated aspect-w-16 aspect-h-9 with modern `aspect-video`
-              embedContainer.className = "w-full aspect-video";
-              const iframe = document.createElement("iframe");
-              iframe.src = embedUrl;
-              iframe.className = "w-full h-full rounded-lg";
-              iframe.title = `YouTube video player for ${songMeta.song_name}`;
-              iframe.frameBorder = "0";
-              iframe.allow = "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture";
-              iframe.allowFullscreen = true;
-              iframe.loading = "lazy";
-              embedContainer.appendChild(iframe);
-            }
-            cardGrid.appendChild(embedContainer);
-
-            card.appendChild(cardGrid);
-            return card;
           },
-          createTrackListItem: (midi, trackPath, trackName, songMeta) => {
-            const itemWrapper = document.createElement("div");
-            itemWrapper.className = "flex justify-between items-center bg-gray-50 px-4 py-3 rounded-lg";
+          renderCurrentSong: (direction = null) => {
+            const catKey = state.categoryKeys[state.categoryIdx];
+            const cat = config.songCategories[catKey];
+            const songId = `${catKey}${utils.pad(state.songIdx + 1)}`;
+            const meta = state.metadata[songId];
+            if (!meta) return;
 
-            let trackLabel;
-            if (midi.id === "human" && songMeta.cover_url) {
-              trackLabel = document.createElement("a");
-              trackLabel.href = songMeta.cover_url;
-              trackLabel.target = "_blank";
-              trackLabel.rel = "noopener noreferrer";
-              trackLabel.className = "text-sm font-medium text-indigo-600 hover:text-indigo-800 hover:underline";
-              trackLabel.textContent = midi.name;
+            // song-view slide-out -> in
+            if (direction) {
+              dom.songView.classList.remove("song-view");
+              dom.songView.classList.add(direction === "next" ? "leaving-left" : "leaving-right");
+              setTimeout(() => {
+                dom.songView.classList.remove("leaving-left", "leaving-right");
+                dom.songView.classList.add("song-view");
+                ui.applySongMeta(catKey, cat, songId, meta);
+              }, 160);
             } else {
-              trackLabel = document.createElement("span");
-              trackLabel.className = "text-sm font-medium text-gray-700";
-              trackLabel.textContent = midi.name;
+              ui.applySongMeta(catKey, cat, songId, meta);
             }
 
-            const playButton = document.createElement("button");
-            playButton.className =
-              "play-btn h-8 w-8 flex-shrink-0 bg-indigo-500 hover:bg-indigo-600 text-white rounded-full flex items-center justify-center transition-transform transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500";
-            playButton.title = `Play ${trackName}`;
-            playButton.dataset.src = trackPath;
-            playButton.dataset.title = trackName;
-            playButton.innerHTML = `<svg class="w-4 h-4 ml-0.5" viewBox="0 0 20 20" fill="currentColor"><path d="M6.3 2.841A1.5 1.5 0 004 4.11V15.89a1.5 1.5 0 002.3 1.269l9.344-5.89a1.5 1.5 0 000-2.538L6.3 2.84z"/></svg>`;
+            // track list + yt embed always updated immediately (not animated)
+            ui.renderTracks(songId, meta);
+            ui.renderYouTube(meta);
 
-            const labelContainer = document.createElement("div");
-            labelContainer.className = "flex-grow truncate mr-2";
-            labelContainer.appendChild(trackLabel);
+            // progress
+            const pct = ((state.songIdx + 1) / cat.count) * 100;
+            dom.songProgressFill.style.width = pct + "%";
 
-            itemWrapper.appendChild(labelContainer);
-            itemWrapper.appendChild(playButton);
-            return itemWrapper;
+            // nav arrow state
+            const atStart = state.categoryIdx === 0 && state.songIdx === 0;
+            const atEnd =
+              state.categoryIdx === state.categoryKeys.length - 1 &&
+              state.songIdx === config.songCategories[state.categoryKeys[state.categoryKeys.length - 1]].count - 1;
+            dom.prevBtn.disabled = atStart;
+            dom.nextBtn.disabled = atEnd;
+          },
+          applySongMeta: (catKey, cat, songId, meta) => {
+            dom.songCategoryBadge.textContent = cat.name;
+            dom.songIndex.textContent = `${utils.pad(state.songIdx + 1)} / ${cat.count} · ${songId}`;
+            dom.songTitle.textContent = meta.song_name || songId;
+          },
+          renderTracks: (songId, meta) => {
+            dom.trackList.innerHTML = "";
+            config.midiFiles.forEach((m, idx) => {
+              const path = `./songs/${songId}/${m.file}`;
+              const title = `${meta.song_name} — ${m.name}`;
+
+              const btn = document.createElement("button");
+              btn.type = "button";
+              btn.className = "track-btn w-full flex items-center gap-2.5 px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-50/60 dark:bg-slate-950/40 text-left";
+              btn.dataset.src = path;
+              btn.dataset.title = title;
+              btn.dataset.id = m.id;
+              btn.dataset.idx = idx;
+
+              const num = document.createElement("span");
+              num.className = "flex-none grid place-items-center w-5 h-5 rounded font-mono text-[10px] text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-800";
+              num.textContent = idx + 1;
+
+              const chip = document.createElement("span");
+              chip.className = utils.tagClass(m.tag);
+              chip.textContent = utils.tagLabel(m.tag);
+
+              const nameWrap = document.createElement("div");
+              nameWrap.className = "flex-1 min-w-0";
+              let label;
+              if (m.id === "human" && meta.cover_url) {
+                label = document.createElement("a");
+                label.href = meta.cover_url;
+                label.target = "_blank";
+                label.rel = "noopener noreferrer";
+                label.className = "text-sm font-medium text-brand-700 dark:text-brand-300 hover:underline truncate block";
+                label.textContent = m.name;
+                label.addEventListener("click", (e) => e.stopPropagation());
+              } else {
+                label = document.createElement("span");
+                label.className = "text-sm font-medium text-slate-700 dark:text-slate-200 truncate block";
+                label.textContent = m.name;
+              }
+              nameWrap.appendChild(label);
+
+              const playIcon = document.createElement("span");
+              playIcon.className = "flex-none grid place-items-center w-7 h-7 rounded-full bg-gradient-to-br from-brand-500 to-accent-500 text-white";
+              playIcon.innerHTML = `<svg class="w-3 h-3 ml-0.5" viewBox="0 0 20 20" fill="currentColor"><path d="M6.3 2.841A1.5 1.5 0 004 4.11V15.89a1.5 1.5 0 002.3 1.269l9.344-5.89a1.5 1.5 0 000-2.538L6.3 2.84z"/></svg>`;
+
+              btn.appendChild(num);
+              btn.appendChild(chip);
+              btn.appendChild(nameWrap);
+              btn.appendChild(playIcon);
+
+              btn.addEventListener("click", () => app.playTrack(btn));
+              dom.trackList.appendChild(btn);
+            });
+
+            // restore highlight if user had a track playing
+            if (state.currentTrackId) {
+              const btn = dom.trackList.querySelector(`.track-btn[data-id="${state.currentTrackId}"]`);
+              btn?.classList.add("playing");
+            }
+          },
+          renderYouTube: (meta) => {
+            dom.ytContainer.innerHTML = "";
+            const url = utils.getYoutubeEmbedUrl(meta.song_url);
+            if (!url) {
+              dom.ytContainer.innerHTML = `<div class="w-full h-full grid place-items-center text-xs text-slate-500">No video</div>`;
+              return;
+            }
+            const ifr = document.createElement("iframe");
+            ifr.src = url;
+            ifr.className = "w-full h-full";
+            ifr.title = `YouTube video player for ${meta.song_name}`;
+            ifr.frameBorder = "0";
+            ifr.allow = "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture";
+            ifr.allowFullscreen = true;
+            ifr.loading = "lazy";
+            dom.ytContainer.appendChild(ifr);
           },
         };
 
-        // --- EVENT HANDLERS & LOGIC ---
+        // ---- App actions ----
         const app = {
           init: async () => {
             dom.player.addVisualizer(dom.visualizer);
-            const metadataMap = await utils.fetchMetadata(config.metadataUrl);
-            if (metadataMap) {
-              ui.renderAll(metadataMap);
-            }
-            dom.songListContainer.addEventListener("click", app.handlePlayClick);
-            dom.navContainer.addEventListener("click", app.handleNavClick);
-            dom.closePlayerBtn.addEventListener("click", app.closePlayer);
+            state.metadata = await utils.fetchMetadata(config.metadataUrl);
+            if (!state.metadata) return;
+
+            ui.buildNav();
+            dom.loadingIndicator.style.display = "none";
+            dom.playerShell.classList.remove("hidden");
+            dom.playerShell.classList.add("flex", "flex-col");
+
+            ui.renderCurrentSong();
+
+            dom.prevBtn.addEventListener("click", () => app.changeSong(-1));
+            dom.nextBtn.addEventListener("click", () => app.changeSong(1));
+            document.addEventListener("keydown", app.handleKey);
           },
-          handlePlayClick: (e) => {
-            const button = e.target.closest(".play-btn");
-            if (!button) return;
+          changeSong: (delta) => {
+            const catKey = state.categoryKeys[state.categoryIdx];
+            const cat = config.songCategories[catKey];
+            let newIdx = state.songIdx + delta;
+            let newCatIdx = state.categoryIdx;
 
+            if (newIdx < 0) {
+              if (newCatIdx > 0) {
+                newCatIdx -= 1;
+                newIdx = config.songCategories[state.categoryKeys[newCatIdx]].count - 1;
+              } else {
+                return;
+              }
+            } else if (newIdx >= cat.count) {
+              if (newCatIdx < state.categoryKeys.length - 1) {
+                newCatIdx += 1;
+                newIdx = 0;
+              } else {
+                return;
+              }
+            }
+
+            const direction = delta > 0 ? "next" : "prev";
+            state.categoryIdx = newCatIdx;
+            state.songIdx = newIdx;
+            state.currentTrackId = null; // reset active track on song change
+            dom.player.stop();
+            dom.nowPlayingTitle.textContent = "Select a track";
+            ui.updateNav();
+            ui.renderCurrentSong(direction);
+          },
+          goToCategory: (idx) => {
+            if (idx === state.categoryIdx) return;
+            state.categoryIdx = idx;
+            state.songIdx = 0;
+            state.currentTrackId = null;
+            dom.player.stop();
+            dom.nowPlayingTitle.textContent = "Select a track";
+            ui.updateNav();
+            ui.renderCurrentSong(idx > state.categoryIdx ? "prev" : "next");
+          },
+          playTrack: (btn) => {
             if (Tone.context.state !== "running") Tone.start();
-
-            dom.nowPlayingTitle.textContent = button.dataset.title;
-            dom.player.src = button.dataset.src;
-
-            dom.bottomPlayer.classList.remove("translate-y-full");
+            dom.trackList.querySelectorAll(".track-btn.playing").forEach((el) => el.classList.remove("playing"));
+            btn.classList.add("playing");
+            state.currentTrackId = btn.dataset.id;
+            dom.nowPlayingTitle.textContent = btn.dataset.title;
+            dom.player.src = btn.dataset.src;
             dom.player.addEventListener("load", () => dom.player.play(), { once: true });
           },
-          handleNavClick: (e) => {
-            e.preventDefault();
-            const link = e.target.closest(".nav-link");
-            if (!link) return;
-
-            const targetCategory = link.dataset.target;
-
-            dom.navContainer.querySelectorAll(".nav-link").forEach((l) => l.classList.remove("active"));
-            link.classList.add("active");
-
-            dom.songListContainer.querySelectorAll(".category-content").forEach((c) => c.classList.remove("active"));
-            document.getElementById(`category-${targetCategory}`).classList.add("active");
+          togglePlay: () => {
+            if (!dom.player.src) return;
+            if (dom.player.playing) dom.player.stop();
+            else dom.player.start();
           },
-          closePlayer: () => {
-            dom.player.stop();
-            dom.bottomPlayer.classList.add("translate-y-full");
+          handleKey: (e) => {
+            // skip if user is typing somewhere (there are no text inputs, but be safe)
+            const tag = (e.target.tagName || "").toLowerCase();
+            if (["input", "textarea", "select"].includes(tag)) return;
+
+            if (e.key === "ArrowRight") {
+              e.preventDefault();
+              app.changeSong(1);
+            } else if (e.key === "ArrowLeft") {
+              e.preventDefault();
+              app.changeSong(-1);
+            } else if (e.key === "[") {
+              e.preventDefault();
+              if (state.categoryIdx > 0) app.goToCategory(state.categoryIdx - 1);
+            } else if (e.key === "]") {
+              e.preventDefault();
+              if (state.categoryIdx < state.categoryKeys.length - 1) app.goToCategory(state.categoryIdx + 1);
+            } else if (e.key === " " || e.code === "Space") {
+              e.preventDefault();
+              app.togglePlay();
+            } else if (/^[1-7]$/.test(e.key)) {
+              const idx = Number(e.key) - 1;
+              const btn = dom.trackList.querySelector(`.track-btn[data-idx="${idx}"]`);
+              if (btn) app.playTrack(btn);
+            }
           },
         };
 
-        // --- START THE APP ---
         app.init();
       });
     </script>

--- a/docs/demo2.html
+++ b/docs/demo2.html
@@ -1,155 +1,341 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Etude: Controllable Generation Demo</title>
+    <title>Etude — Interactive Style Control</title>
+
+    <script>
+      (function () {
+        if (localStorage.getItem("etude-theme") === "dark") document.documentElement.classList.add("dark");
+      })();
+    </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ["Inter", "Noto Sans TC", "ui-sans-serif", "system-ui"],
+              display: ["Space Grotesk", "Inter", "ui-sans-serif", "system-ui"],
+              mono: ["JetBrains Mono", "ui-monospace", "monospace"],
+            },
+            colors: {
+              brand: { 300: "#a5b4fc", 500: "#6366f1", 600: "#4f46e5", 700: "#4338ca" },
+              accent: { 500: "#14b8a6", 600: "#0d9488" },
+            },
+          },
+        },
+      };
+    </script>
+
     <script src="https://cdn.jsdelivr.net/combine/npm/tone@14.7.58,npm/@magenta/music@1.23.1/es6/core.js,npm/focus-visible@5,npm/html-midi-player@1.5.0"></script>
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500&family=Noto+Sans+TC:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
 
     <style>
-      body {
-        font-family: "Inter", "Noto Sans TC", sans-serif;
+      :root { color-scheme: light dark; }
+      html, body { height: 100%; }
+      body { overflow: hidden; }
+      @media (max-width: 1023px) {
+        body { overflow: auto; }
       }
+
+      /* Custom range slider */
+      input[type="range"].etude-slider {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 100%;
+        height: 6px;
+        background: linear-gradient(90deg, #6366f1 0%, #14b8a6 var(--pct, 50%), #e5e7eb var(--pct, 50%), #e5e7eb 100%);
+        border-radius: 999px;
+        outline: none;
+        transition: background 0.2s;
+      }
+      .dark input[type="range"].etude-slider {
+        background: linear-gradient(90deg, #a5b4fc 0%, #2dd4bf var(--pct, 50%), #1e293b var(--pct, 50%), #1e293b 100%);
+      }
+      input[type="range"].etude-slider::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        background: #fff;
+        border: 2px solid #4f46e5;
+        box-shadow: 0 2px 6px rgba(79, 70, 229, 0.35);
+        cursor: pointer;
+        transition: transform 0.1s, box-shadow 0.2s;
+      }
+      .dark input[type="range"].etude-slider::-webkit-slider-thumb {
+        background: #0b1220;
+        border-color: #a5b4fc;
+        box-shadow: 0 2px 8px rgba(165, 180, 252, 0.35);
+      }
+      input[type="range"].etude-slider::-webkit-slider-thumb:hover { transform: scale(1.1); }
+      input[type="range"].etude-slider::-moz-range-thumb {
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        background: #fff;
+        border: 2px solid #4f46e5;
+        cursor: pointer;
+      }
+
+      .step-pill {
+        font-family: "JetBrains Mono", monospace;
+        font-size: 0.68rem;
+        padding: 0.1rem 0.45rem;
+        border-radius: 9999px;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+      .step-pill.active {
+        background: linear-gradient(90deg, rgba(99,102,241,0.18), rgba(20,184,166,0.18));
+        color: #4338ca;
+      }
+      .dark .step-pill.active { color: #a5b4fc; }
+
+      /* Player skin */
       #player::part(control-panel) {
-        background: #f9fafb; /* gray-50 */
-        border: 1px solid #e5e7eb; /* gray-200 */
+        background: transparent;
+        border: none;
       }
+      #player::part(play-button) { color: #4f46e5; }
+      .dark #player::part(play-button) { color: #a5b4fc; }
+      #player::part(time) { font-family: "JetBrains Mono", monospace; font-size: 0.75rem; }
       #visualizer {
-        border: 1px solid #e5e7eb; /* gray-200 */
+        border-radius: 10px;
+        border: 1px solid rgb(226 232 240);
+        background: #fff;
+        width: 100%;
+        height: 100%;
+      }
+      .dark #visualizer {
+        border-color: rgb(30 41 59);
+        background: #0b1220;
+      }
+
+      .aurora-sub {
+        background:
+          radial-gradient(50% 60% at 15% 0%, rgba(20, 184, 166, 0.12), transparent 60%),
+          radial-gradient(40% 50% at 90% 10%, rgba(99, 102, 241, 0.1), transparent 60%);
+      }
+      .dark .aurora-sub {
+        background:
+          radial-gradient(50% 60% at 15% 0%, rgba(20, 184, 166, 0.2), transparent 60%),
+          radial-gradient(40% 50% at 90% 10%, rgba(99, 102, 241, 0.15), transparent 60%);
+      }
+
+      kbd {
+        font-family: "JetBrains Mono", monospace;
+        font-size: 0.7rem;
+        padding: 0.1rem 0.4rem;
+        border-radius: 4px;
+        background: rgb(241 245 249);
+        border: 1px solid rgb(203 213 225);
+        border-bottom-width: 2px;
+        color: rgb(71 85 105);
+      }
+      .dark kbd {
+        background: rgb(30 41 59);
+        border-color: rgb(51 65 85);
+        color: rgb(203 213 225);
+      }
+
+      /* Tab switcher */
+      .tab-btn {
+        color: rgb(100 116 139);
+      }
+      .tab-btn:hover {
+        color: rgb(51 65 85);
+      }
+      .dark .tab-btn {
+        color: rgb(148 163 184);
+      }
+      .dark .tab-btn:hover {
+        color: rgb(226 232 240);
+      }
+      .tab-btn.active {
+        background: #fff;
+        color: #4f46e5;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+      }
+      .dark .tab-btn.active {
+        background: rgb(15 23 42);
+        color: #a5b4fc;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
       }
     </style>
   </head>
-  <body class="bg-gray-100 text-gray-800">
-    <header class="text-center py-8 bg-white border-b border-gray-200">
-      <div class="container mx-auto px-4 relative">
-        <a
-          href="index.html"
-          class="absolute top-1/2 -translate-y-1/2 left-4 md:left-8 inline-flex items-center text-gray-500 hover:text-indigo-600 transition-colors"
-        >
-          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
-          </svg>
+
+  <body class="font-sans bg-slate-50 text-slate-800 dark:bg-slate-950 dark:text-slate-200 antialiased selection:bg-accent-500/25 flex flex-col">
+    <!-- Top bar -->
+    <div class="flex-none backdrop-blur bg-white/70 dark:bg-slate-950/70 border-b border-slate-200/60 dark:border-slate-800/60 relative overflow-hidden">
+      <div class="absolute inset-0 aurora-sub pointer-events-none"></div>
+      <div class="container mx-auto px-4 h-12 flex items-center justify-between relative">
+        <a href="index.html" class="inline-flex items-center gap-2 text-sm font-medium text-slate-600 dark:text-slate-300 hover:text-brand-700 dark:hover:text-brand-300 transition">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
           Back
         </a>
-        <h1 class="text-3xl md:text-4xl font-bold text-gray-900">Interactive Controllable Generation</h1>
-        <p class="mt-3 text-base text-gray-600 max-w-3xl mx-auto">Adjust the sliders to change the musical attributes and listen to the result in real-time.</p>
+        <a href="index.html" class="flex items-center gap-2 font-display font-semibold tracking-tight">
+          <span class="inline-grid place-items-center w-6 h-6 rounded-md bg-gradient-to-br from-brand-500 to-accent-500 text-white text-[10px]">E</span>
+          <span class="text-slate-900 dark:text-slate-100 text-sm">Etude</span>
+          <span class="hidden sm:inline text-xs font-mono font-normal text-slate-500 dark:text-slate-400">/ style control</span>
+        </a>
+        <button id="theme-toggle" type="button" aria-label="Toggle theme" class="grid place-items-center w-8 h-8 rounded-md border border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 transition">
+          <svg class="w-3.5 h-3.5 block dark:hidden" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+          <svg class="w-3.5 h-3.5 hidden dark:block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
       </div>
-    </header>
+    </div>
 
-    <main class="container mx-auto p-4 md:p-8">
-      <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        <div class="lg:col-span-1 bg-white p-6 rounded-xl shadow-md">
-          <h2 class="text-2xl font-bold mb-6 text-gray-800 border-b pb-4">Style Attributes</h2>
-          <div class="space-y-6">
-            <div>
-              <label for="polyphony" class="flex justify-between items-center text-lg font-semibold text-gray-700">
-                Polyphony
-                <span id="polyphony-value" class="text-indigo-600 font-bold text-xl">1</span>
-              </label>
-              <input
-                id="polyphony-slider"
-                type="range"
-                min="0"
-                max="2"
-                value="1"
-                step="1"
-                class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-              />
-              <div class="flex justify-between text-sm text-gray-500 mt-1">
-                <span>Sparse</span>
-                <span>Medium</span>
-                <span>Dense</span>
+    <!-- Main: 3-column grid, fills remaining height -->
+    <main class="flex-1 min-h-0">
+      <div class="container mx-auto h-full px-3 md:px-6 py-3 md:py-4">
+        <div class="h-full grid grid-cols-1 lg:grid-cols-5 gap-3 md:gap-4">
+          <!-- Left: Controls -->
+          <section class="lg:col-span-2 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-4 md:p-5 flex flex-col min-h-0">
+            <div class="flex items-start justify-between mb-1">
+              <div>
+                <p class="text-[10px] uppercase font-mono tracking-wider text-accent-600 dark:text-accent-500">Demo 02</p>
+                <h1 class="mt-0.5 font-display text-lg md:text-xl font-bold text-slate-900 dark:text-white">Style Attributes</h1>
+              </div>
+              <button id="reset-btn" type="button" class="text-xs font-mono text-slate-500 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300 transition inline-flex items-center gap-1.5">
+                <svg class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/></svg>
+                reset
+              </button>
+            </div>
+            <p class="text-xs text-slate-500 dark:text-slate-400 mb-4">
+              Move the sliders or click the labels below each one. Playback updates immediately.
+            </p>
+
+            <div class="flex-1 min-h-0 flex flex-col justify-around gap-5">
+              <!-- Polyphony -->
+              <div>
+                <div class="flex items-center justify-between mb-1">
+                  <label for="polyphony-slider" class="text-sm font-semibold text-slate-800 dark:text-slate-200">Polyphony</label>
+                  <span id="polyphony-value" class="font-mono text-xs text-brand-700 dark:text-brand-300">1</span>
+                </div>
+                <p class="text-[11px] leading-snug text-slate-500 dark:text-slate-400 mb-2">
+                  Density of the harmonic texture — shifts between sparse arpeggios and denser chords.
+                </p>
+                <input id="polyphony-slider" type="range" min="0" max="2" value="1" step="1" class="etude-slider" />
+                <div class="mt-1.5 flex justify-between text-[10px] uppercase tracking-wide font-mono text-slate-500 dark:text-slate-400">
+                  <span data-step="0" data-slider="polyphony" class="step-pill">Sparse</span>
+                  <span data-step="1" data-slider="polyphony" class="step-pill active">Medium</span>
+                  <span data-step="2" data-slider="polyphony" class="step-pill">Dense</span>
+                </div>
+              </div>
+
+              <!-- Rhythm Intensity -->
+              <div>
+                <div class="flex items-center justify-between mb-1">
+                  <label for="rhythm-slider" class="text-sm font-semibold text-slate-800 dark:text-slate-200">Rhythm Intensity</label>
+                  <span id="rhythm-value" class="font-mono text-xs text-brand-700 dark:text-brand-300">1</span>
+                </div>
+                <p class="text-[11px] leading-snug text-slate-500 dark:text-slate-400 mb-2">
+                  Density of rhythmic events over time — higher yields a more complex, rhythmically active phrase.
+                </p>
+                <input id="rhythm-slider" type="range" min="0" max="2" value="1" step="1" class="etude-slider" />
+                <div class="mt-1.5 flex justify-between text-[10px] uppercase tracking-wide font-mono text-slate-500 dark:text-slate-400">
+                  <span data-step="0" data-slider="rhythm" class="step-pill">Simple</span>
+                  <span data-step="1" data-slider="rhythm" class="step-pill active">Medium</span>
+                  <span data-step="2" data-slider="rhythm" class="step-pill">Complex</span>
+                </div>
+              </div>
+
+              <!-- Note Sustain -->
+              <div>
+                <div class="flex items-center justify-between mb-1">
+                  <label for="sustain-slider" class="text-sm font-semibold text-slate-800 dark:text-slate-200">Note Sustain</label>
+                  <span id="sustain-value" class="font-mono text-xs text-brand-700 dark:text-brand-300">1</span>
+                </div>
+                <p class="text-[11px] leading-snug text-slate-500 dark:text-slate-400 mb-2">
+                  Average note duration — controls articulation from staccato (short) to legato (smooth, connected).
+                </p>
+                <input id="sustain-slider" type="range" min="0" max="2" value="1" step="1" class="etude-slider" />
+                <div class="mt-1.5 flex justify-between text-[10px] uppercase tracking-wide font-mono text-slate-500 dark:text-slate-400">
+                  <span data-step="0" data-slider="sustain" class="step-pill">Staccato</span>
+                  <span data-step="1" data-slider="sustain" class="step-pill active">Medium</span>
+                  <span data-step="2" data-slider="sustain" class="step-pill">Legato</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <!-- Right: Player + piano roll / origin video (tabbed) -->
+          <section class="lg:col-span-3 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-4 md:p-5 flex flex-col min-h-0">
+            <div class="flex items-center justify-between mb-3 gap-3 flex-wrap">
+              <div class="flex items-center gap-2">
+                <span class="flex items-center gap-1">
+                  <span class="inline-block w-1 h-3 rounded-sm bg-brand-500 animate-pulse"></span>
+                  <span class="inline-block w-1 h-4 rounded-sm bg-brand-400 animate-pulse [animation-delay:120ms]"></span>
+                  <span class="inline-block w-1 h-2.5 rounded-sm bg-accent-500 animate-pulse [animation-delay:240ms]"></span>
+                </span>
+                <div>
+                  <p class="text-[10px] uppercase font-mono tracking-wider text-accent-600 dark:text-accent-500">Live Demo</p>
+                  <h2 id="now-playing-title" class="text-sm md:text-base font-semibold text-slate-900 dark:text-slate-100 truncate">Controllable Performance</h2>
+                </div>
+              </div>
+
+              <!-- Tab switcher -->
+              <div role="tablist" aria-label="View switcher" class="inline-flex items-center rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-100/60 dark:bg-slate-800/60 p-0.5 text-xs font-medium">
+                <button id="tab-piano" role="tab" aria-selected="true" data-tab="piano" type="button" class="tab-btn active px-3 py-1 rounded-md transition">Piano Roll</button>
+                <button id="tab-origin" role="tab" aria-selected="false" data-tab="origin" type="button" class="tab-btn px-3 py-1 rounded-md transition">Origin Video</button>
               </div>
             </div>
 
-            <div>
-              <label for="rhythm" class="flex justify-between items-center text-lg font-semibold text-gray-700">
-                Rhythm Intensity
-                <span id="rhythm-value" class="text-indigo-600 font-bold text-xl">1</span>
-              </label>
-              <input
-                id="rhythm-slider"
-                type="range"
-                min="0"
-                max="2"
-                value="1"
-                step="1"
-                class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-              />
-              <div class="flex justify-between text-sm text-gray-500 mt-1">
-                <span>Simple</span>
-                <span>Medium</span>
-                <span>Complex</span>
+            <div class="flex-1 min-h-0 rounded-lg overflow-hidden relative">
+              <!-- Piano roll panel -->
+              <div id="panel-piano" role="tabpanel" aria-labelledby="tab-piano" class="absolute inset-0">
+                <midi-visualizer type="piano-roll" id="visualizer"></midi-visualizer>
+              </div>
+
+              <!-- Origin video panel -->
+              <div id="panel-origin" role="tabpanel" aria-labelledby="tab-origin" class="absolute inset-0 hidden bg-black">
+                <iframe
+                  id="origin-iframe"
+                  class="w-full h-full"
+                  data-src="https://www.youtube.com/embed/RCaTLn4qoz4"
+                  title="YouTube video player — Mrs. GREEN APPLE — クスシキ"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowfullscreen
+                ></iframe>
               </div>
             </div>
 
-            <div>
-              <label for="sustain" class="flex justify-between items-center text-lg font-semibold text-gray-700">
-                Note Sustain
-                <span id="sustain-value" class="text-indigo-600 font-bold text-xl">1</span>
-              </label>
-              <input
-                id="sustain-slider"
-                type="range"
-                min="0"
-                max="2"
-                value="1"
-                step="1"
-                class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-              />
-              <div class="flex justify-between text-sm text-gray-500 mt-1">
-                <span>Staccato</span>
-                <span>Medium</span>
-                <span>Legato</span>
-              </div>
+            <div id="player-wrap" class="mt-3 flex-none">
+              <midi-player id="player" sound-font class="w-full"></midi-player>
             </div>
-          </div>
-        </div>
 
-        <div class="lg:col-span-2 bg-white p-6 rounded-xl shadow-md">
-          <h2 id="now-playing-title" class="text-2xl font-bold mb-4 text-gray-800">Live Demo</h2>
-          <midi-player id="player" sound-font class="w-full"></midi-player>
-          <midi-visualizer type="piano-roll" id="visualizer" class="mt-4 rounded-lg"></midi-visualizer>
-        </div>
-
-        <div class="lg:col-span-2 bg-white p-6 rounded-xl shadow-md">
-          <h2 class="text-2xl font-bold mb-4 text-gray-800">Origin Song: Mrs. GREEN APPLE - クスシキ</h2>
-          <div class="w-full aspect-video">
-            <iframe
-              class="w-full h-full rounded-lg"
-              src="https://www.youtube.com/embed/RCaTLn4qoz4"
-              title="YouTube video player for Etude Project"
-              frameborder="0"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowfullscreen
-            >
-            </iframe>
-          </div>
+            <p id="origin-caption" class="mt-2 text-[11px] text-slate-400 dark:text-slate-500 hidden text-center">
+              Origin: Mrs. GREEN APPLE — クスシキ
+            </p>
+          </section>
         </div>
       </div>
     </main>
 
-    <footer class="text-center py-4">
-      <div class="container mx-auto px-4">
-        <p class="text-xs text-gray-500">
-          MIDI Player & Visualizer powered by
-          <a href="https://github.com/cifkao/html-midi-player" target="_blank" rel="noopener noreferrer" class="underline hover:text-gray-700">
-            html-midi-player
-          </a>
-          by Ondřej Cífka.
-        </p>
+    <!-- Keyboard hint footer -->
+    <div class="flex-none hidden lg:block border-t border-slate-200/60 dark:border-slate-800/60 bg-white/70 dark:bg-slate-950/70 backdrop-blur">
+      <div class="container mx-auto px-4 py-1.5 flex items-center justify-center gap-4 text-[11px] text-slate-500 dark:text-slate-400">
+        <span><kbd>Space</kbd> play/pause</span>
+        <span><kbd>R</kbd> reset</span>
+        <span class="hidden xl:inline">MIDI playback via <a href="https://github.com/cifkao/html-midi-player" target="_blank" rel="noopener noreferrer" class="underline hover:text-slate-700 dark:hover:text-slate-300">html-midi-player</a></span>
       </div>
-    </footer>
+    </div>
 
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        // --- DOM ELEMENT REFERENCES ---
         const dom = {
           polyphonySlider: document.getElementById("polyphony-slider"),
           rhythmSlider: document.getElementById("rhythm-slider"),
@@ -159,52 +345,130 @@
           sustainValue: document.getElementById("sustain-value"),
           player: document.getElementById("player"),
           visualizer: document.getElementById("visualizer"),
-          nowPlayingTitle: document.getElementById("now-playing-title"),
+          resetBtn: document.getElementById("reset-btn"),
+          themeToggle: document.getElementById("theme-toggle"),
+          tabBtns: document.querySelectorAll(".tab-btn"),
+          panelPiano: document.getElementById("panel-piano"),
+          panelOrigin: document.getElementById("panel-origin"),
+          originIframe: document.getElementById("origin-iframe"),
+          originCaption: document.getElementById("origin-caption"),
+          playerWrap: document.getElementById("player-wrap"),
         };
 
-        // Link player to visualizer
+        dom.themeToggle.addEventListener("click", () => {
+          const root = document.documentElement;
+          root.classList.toggle("dark");
+          localStorage.setItem("etude-theme", root.classList.contains("dark") ? "dark" : "light");
+        });
+
         dom.player.addVisualizer(dom.visualizer);
 
-        // --- CORE LOGIC ---
-        function updateMidiPlayer() {
-          // 1. Get current values from sliders
+        const sliders = [
+          { el: dom.polyphonySlider, key: "polyphony", valEl: dom.polyphonyValue },
+          { el: dom.rhythmSlider, key: "rhythm", valEl: dom.rhythmValue },
+          { el: dom.sustainSlider, key: "sustain", valEl: dom.sustainValue },
+        ];
+
+        function setSliderFill(input) {
+          const min = Number(input.min);
+          const max = Number(input.max);
+          const pct = ((Number(input.value) - min) / (max - min)) * 100;
+          input.style.setProperty("--pct", pct + "%");
+        }
+
+        function setActiveStep(sliderKey, step) {
+          document.querySelectorAll(`[data-slider="${sliderKey}"]`).forEach((el) => {
+            el.classList.toggle("active", Number(el.dataset.step) === Number(step));
+          });
+        }
+
+        function update() {
           const polyphony = dom.polyphonySlider.value;
           const rhythm = dom.rhythmSlider.value;
           const sustain = dom.sustainSlider.value;
 
-          // 2. Update the text labels next to the sliders
           dom.polyphonyValue.textContent = polyphony;
           dom.rhythmValue.textContent = rhythm;
           dom.sustainValue.textContent = sustain;
 
-          // 3. Construct the filename based on the slider values
+          sliders.forEach((s) => {
+            setSliderFill(s.el);
+            setActiveStep(s.key, s.el.value);
+          });
+
           const filename = `${polyphony}${rhythm}${sustain}.mid`;
           const filePath = `./songs/style_demo/${filename}`;
-
-          // 4. Update the player source and title
-          // We check if the source has actually changed to avoid unnecessary reloads
           if (dom.player.src !== new URL(filePath, window.location.href).href) {
-            dom.player.stop(); // Stop current playback
+            dom.player.stop();
             dom.player.src = filePath;
-            dom.nowPlayingTitle.textContent = `Live Demo`;
           }
         }
 
-        // --- EVENT LISTENERS ---
-        // Add a single event listener to the container for efficiency
-        const controlsContainer = document.querySelector(".lg\\:col-span-1");
-        controlsContainer.addEventListener("input", (event) => {
-          if (event.target.type === "range") {
-            if (Tone.context.state !== "running") {
-              Tone.start();
+        sliders.forEach((s) => {
+          s.el.addEventListener("input", () => {
+            if (Tone.context.state !== "running") Tone.start();
+            update();
+          });
+        });
+
+        document.querySelectorAll(".step-pill").forEach((pill) => {
+          pill.addEventListener("click", () => {
+            const key = pill.dataset.slider;
+            const step = pill.dataset.step;
+            const target = sliders.find((s) => s.key === key);
+            if (!target) return;
+            target.el.value = step;
+            if (Tone.context.state !== "running") Tone.start();
+            update();
+          });
+        });
+
+        dom.resetBtn.addEventListener("click", () => {
+          sliders.forEach((s) => (s.el.value = 1));
+          update();
+        });
+
+        // Tab switching: Piano Roll / Origin Video
+        function setTab(name) {
+          const isPiano = name === "piano";
+          dom.tabBtns.forEach((b) => {
+            const active = b.dataset.tab === name;
+            b.classList.toggle("active", active);
+            b.setAttribute("aria-selected", active ? "true" : "false");
+          });
+          dom.panelPiano.classList.toggle("hidden", !isPiano);
+          dom.panelOrigin.classList.toggle("hidden", isPiano);
+          dom.originCaption.classList.toggle("hidden", isPiano);
+          dom.playerWrap.classList.toggle("hidden", !isPiano);
+
+          if (!isPiano) {
+            if (dom.player.playing) dom.player.stop();
+            if (!dom.originIframe.getAttribute("src")) {
+              dom.originIframe.setAttribute("src", dom.originIframe.dataset.src);
             }
-            updateMidiPlayer();
+          } else {
+            dom.originIframe.removeAttribute("src");
+          }
+        }
+        dom.tabBtns.forEach((b) => b.addEventListener("click", () => setTab(b.dataset.tab)));
+
+        // Keyboard
+        document.addEventListener("keydown", (e) => {
+          const tag = (e.target.tagName || "").toLowerCase();
+          if (["input", "textarea", "select"].includes(tag)) return;
+          if (e.key === " " || e.code === "Space") {
+            e.preventDefault();
+            if (!dom.player.src) return;
+            if (dom.player.playing) dom.player.stop();
+            else dom.player.start();
+          } else if (e.key === "r" || e.key === "R") {
+            e.preventDefault();
+            sliders.forEach((s) => (s.el.value = 1));
+            update();
           }
         });
 
-        // --- INITIALIZATION ---
-        // Load the default MIDI file (111.mid) when the page loads
-        updateMidiPlayer();
+        update();
       });
     </script>
   </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,128 +1,507 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Etude: A Controllable Music Generation Project</title>
+    <title>Etude — Controllable Piano Cover Generation</title>
+    <meta name="description" content="Etude: a three-stage deep learning system for expressive piano cover generation with nuanced style control." />
+
+    <script>
+      // Theme init (no flash). Default: light. Users who opt into dark via the toggle have it remembered.
+      (function () {
+        if (localStorage.getItem("etude-theme") === "dark") document.documentElement.classList.add("dark");
+      })();
+    </script>
+
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ["Inter", "Noto Sans TC", "ui-sans-serif", "system-ui"],
+              display: ["Space Grotesk", "Inter", "ui-sans-serif", "system-ui"],
+              mono: ["JetBrains Mono", "ui-monospace", "monospace"],
+            },
+            colors: {
+              brand: {
+                50: "#eef2ff",
+                100: "#e0e7ff",
+                300: "#a5b4fc",
+                500: "#6366f1",
+                600: "#4f46e5",
+                700: "#4338ca",
+              },
+              accent: {
+                500: "#14b8a6",
+                600: "#0d9488",
+              },
+            },
+            keyframes: {
+              "fade-up": {
+                "0%": { opacity: "0", transform: "translateY(12px)" },
+                "100%": { opacity: "1", transform: "translateY(0)" },
+              },
+              "slow-pan": {
+                "0%,100%": { transform: "translate3d(0,0,0)" },
+                "50%": { transform: "translate3d(-2%,-1%,0)" },
+              },
+            },
+            animation: {
+              "fade-up": "fade-up 0.6s ease-out both",
+              "slow-pan": "slow-pan 18s ease-in-out infinite",
+            },
+          },
+        },
+      };
+    </script>
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500&family=Noto+Sans+TC:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+
     <style>
+      :root {
+        color-scheme: light dark;
+      }
       body {
-        font-family: "Inter", "Noto Sans TC", sans-serif;
+        font-feature-settings: "cv11", "ss01";
+      }
+      /* Grid / dot background */
+      .bg-grid {
+        background-image: radial-gradient(circle at 1px 1px, rgba(99, 102, 241, 0.15) 1px, transparent 0);
+        background-size: 24px 24px;
+      }
+      .dark .bg-grid {
+        background-image: radial-gradient(circle at 1px 1px, rgba(165, 180, 252, 0.12) 1px, transparent 0);
+      }
+      /* Radial aurora — cooler, more restrained */
+      .aurora {
+        background:
+          radial-gradient(55% 45% at 15% 20%, rgba(99, 102, 241, 0.18), transparent 65%),
+          radial-gradient(45% 40% at 85% 10%, rgba(20, 184, 166, 0.14), transparent 65%),
+          radial-gradient(50% 40% at 50% 100%, rgba(99, 102, 241, 0.1), transparent 65%);
+      }
+      .dark .aurora {
+        background:
+          radial-gradient(55% 45% at 15% 20%, rgba(99, 102, 241, 0.3), transparent 65%),
+          radial-gradient(45% 40% at 85% 10%, rgba(20, 184, 166, 0.22), transparent 65%),
+          radial-gradient(50% 40% at 50% 100%, rgba(99, 102, 241, 0.15), transparent 65%);
+      }
+
+      /* Animated music bars (hero visual) */
+      .eq-bar {
+        fill: url(#eqGrad);
+        transform-origin: bottom;
+        animation: eq-pulse 1.4s ease-in-out infinite;
+      }
+      @keyframes eq-pulse {
+        0%, 100% { transform: scaleY(0.5); }
+        50% { transform: scaleY(1); }
+      }
+
+      /* Gradient ring for arXiv pill */
+      .grad-ring {
+        position: relative;
+        background: rgb(255 255 255 / 0.7);
+      }
+      .dark .grad-ring { background: rgb(15 23 42 / 0.7); }
+      .grad-ring::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: 9999px;
+        padding: 1px;
+        background: linear-gradient(90deg, rgba(99,102,241,0.6), rgba(20,184,166,0.6));
+        -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+                mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+        -webkit-mask-composite: xor;
+                mask-composite: exclude;
+        pointer-events: none;
+      }
+
+      /* Button shine sweep on hover */
+      .btn-primary {
+        background: linear-gradient(120deg, #1e293b 0%, #0f172a 100%);
+        position: relative;
+        overflow: hidden;
+      }
+      .btn-primary::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(100deg, transparent 30%, rgba(255,255,255,0.18) 50%, transparent 70%);
+        transform: translateX(-100%);
+        transition: transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+      }
+      .btn-primary:hover::after { transform: translateX(100%); }
+      .dark .btn-primary {
+        background: linear-gradient(120deg, #ffffff 0%, #e2e8f0 100%);
+        color: #0f172a;
+      }
+
+      .btn-accent {
+        background: linear-gradient(120deg, #4f46e5 0%, #0d9488 100%);
+      }
+      .btn-accent:hover { filter: brightness(1.08); }
+      .reveal {
+        opacity: 0;
+        transform: translateY(14px);
+        transition: opacity 0.7s ease, transform 0.7s ease;
+      }
+      .reveal.in {
+        opacity: 1;
+        transform: none;
+      }
+      /* Copy button */
+      .copy-btn:active {
+        transform: scale(0.97);
+      }
+      pre.bibtex {
+        font-family: "JetBrains Mono", ui-monospace, monospace;
+        font-size: 0.8rem;
+        line-height: 1.55;
       }
     </style>
   </head>
-  <body class="bg-gray-50 text-gray-800">
-    <header class="text-center py-10 md:py-16 bg-white border-b border-gray-200">
-      <div class="container mx-auto px-4">
-        <h1 class="text-3xl md:text-5xl font-bold text-gray-900">
-          Etude: Piano Cover Generation with a Three-Stage Approach — Extract, strucTUralize, and DEcode.
-        </h1>
-        <p class="mt-4 text-base md:text-lg text-gray-600 max-w-6xl mx-auto md:max-w-4xl">
-          This project presents the Etude model, a deep learning system for expressive piano cover generation. It can be conditioned on high-level musical
-          attributes, allowing for nuanced control over the generated performance's style.
-        </p>
+
+  <body class="font-sans bg-slate-50 text-slate-800 dark:bg-slate-950 dark:text-slate-200 antialiased selection:bg-brand-600/25">
+    <!-- Top bar -->
+    <div class="sticky top-0 z-40 backdrop-blur bg-white/70 dark:bg-slate-950/70 border-b border-slate-200/60 dark:border-slate-800/60">
+      <div class="container mx-auto px-4 h-14 flex items-center justify-between">
+        <a href="#top" class="flex items-center gap-2 font-display font-semibold tracking-tight">
+          <span class="inline-grid place-items-center w-7 h-7 rounded-md bg-gradient-to-br from-brand-500 to-accent-500 text-white text-xs">E</span>
+          <span class="text-slate-900 dark:text-slate-100">Etude</span>
+          <span class="hidden sm:inline text-xs font-mono font-normal text-slate-500 dark:text-slate-400">/ piano cover generation</span>
+        </a>
+        <div class="flex items-center gap-1">
+          <a href="#demos" class="hidden sm:inline px-3 py-1.5 text-sm rounded-md hover:bg-slate-100 dark:hover:bg-slate-800">Demos</a>
+          <a href="#resources" class="hidden sm:inline px-3 py-1.5 text-sm rounded-md hover:bg-slate-100 dark:hover:bg-slate-800">Resources</a>
+          <a href="#cite" class="hidden sm:inline px-3 py-1.5 text-sm rounded-md hover:bg-slate-100 dark:hover:bg-slate-800">Cite</a>
+          <button
+            id="theme-toggle"
+            type="button"
+            aria-label="Toggle theme"
+            class="ml-1 grid place-items-center w-9 h-9 rounded-md border border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 transition"
+          >
+            <svg class="w-4 h-4 block dark:hidden" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+            <svg class="w-4 h-4 hidden dark:block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Hero -->
+    <header id="top" class="relative overflow-hidden">
+      <div class="absolute inset-0 aurora animate-slow-pan pointer-events-none"></div>
+      <div class="absolute inset-0 bg-grid [mask-image:radial-gradient(ellipse_at_center,black_35%,transparent_75%)] pointer-events-none"></div>
+
+      <div class="relative container mx-auto px-4 pt-14 pb-16 md:pt-20 md:pb-24">
+        <div class="grid gap-10 md:gap-12 lg:grid-cols-12 items-center">
+          <!-- Left: copy + actions -->
+          <div class="lg:col-span-7 text-left">
+            <!-- Badges row -->
+            <div class="flex flex-wrap items-center gap-2 animate-fade-up">
+              <a href="https://arxiv.org/abs/2509.16522" target="_blank" rel="noopener noreferrer" class="grad-ring inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-mono backdrop-blur hover:brightness-105 transition">
+                <span class="w-1.5 h-1.5 rounded-full bg-accent-500 animate-pulse"></span>
+                arXiv:2509.16522
+                <span class="text-slate-400 dark:text-slate-500">·</span>
+                <span class="text-slate-500 dark:text-slate-400">Preprint</span>
+              </a>
+              <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-mono text-slate-500 dark:text-slate-400 border border-slate-200 dark:border-slate-700 bg-white/60 dark:bg-slate-900/60 backdrop-blur">
+                <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor"><path d="M12 3a6 6 0 016 6v2a6 6 0 01-12 0V9a6 6 0 016-6zm1 14.93A8 8 0 0020 10h-2a6 6 0 11-12 0H4a8 8 0 007 7.93V21h2v-3.07z"/></svg>
+                Piano cover generation
+              </span>
+            </div>
+
+            <h1 class="mt-6 font-display text-[2.25rem] md:text-[3rem] lg:text-[3.5rem] leading-[1.05] font-bold tracking-tight text-slate-900 dark:text-white animate-fade-up [animation-delay:80ms]">
+              Expressive piano covers,
+              <span class="block bg-gradient-to-r from-brand-600 to-accent-600 dark:from-brand-300 dark:to-accent-500 bg-clip-text text-transparent">steerable by design.</span>
+            </h1>
+
+            <p class="mt-5 max-w-xl text-base md:text-lg text-slate-600 dark:text-slate-300 animate-fade-up [animation-delay:160ms]">
+              A three-stage deep learning system that lifts a source track into a symbolic form, imposes musical structure, and decodes a stylized performance — conditioned on high-level attributes like polyphony, rhythm intensity, and note sustain.
+            </p>
+
+            <!-- Pipeline chips -->
+            <div class="mt-6 flex flex-wrap items-center gap-x-2 gap-y-2 text-[13px] font-mono animate-fade-up [animation-delay:200ms]">
+              <span class="px-2.5 py-1 rounded-md bg-brand-50 dark:bg-brand-600/15 text-brand-700 dark:text-brand-300">Extract</span>
+              <span class="text-slate-400 dark:text-slate-500">→</span>
+              <span class="px-2.5 py-1 rounded-md bg-fuchsia-50 dark:bg-fuchsia-500/15 text-fuchsia-700 dark:text-fuchsia-300">strucTUralize</span>
+              <span class="text-slate-400 dark:text-slate-500">→</span>
+              <span class="px-2.5 py-1 rounded-md bg-teal-50 dark:bg-teal-500/15 text-teal-700 dark:text-teal-300">DEcode</span>
+            </div>
+
+            <!-- Primary actions -->
+            <div class="mt-8 flex flex-wrap gap-3 animate-fade-up [animation-delay:240ms]">
+              <a href="demo1.html" class="btn-primary group inline-flex items-center gap-2 px-5 py-3 rounded-lg font-semibold text-white shadow-sm transition">
+                <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="m15.81 10l-2.5-5H14a.5.5 0 0 0 0-1h-.79a6.04 6.04 0 0 0-4.198-1.95L9 2a1 1 0 0 0-2 0v.05a6.17 6.17 0 0 0-4.247 1.947L2 4a.5.5 0 0 0 0 1h.69l-2.5 5H0c0 1.1 1.34 2 3 2s3-.9 3-2h-.19L3.26 4.91a.5.5 0 0 0 .159-.148A4.84 4.84 0 0 1 6.994 3.06L7 14H6v1H4v1h8v-1h-2v-1H9V3.06a4.7 4.7 0 0 1 3.524 1.693a.5.5 0 0 0 .193.186L10.19 10H10c0 1.1 1.34 2 3 2s3-.9 3-2zM5 10H1l2-3.94zm6 0l2-3.94L15 10z"/></svg>
+                Model Comparison
+                <svg class="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5 relative z-[1]" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02z" clip-rule="evenodd"/></svg>
+              </a>
+              <a href="demo2.html" class="btn-accent group inline-flex items-center gap-2 px-5 py-3 rounded-lg font-semibold text-white shadow-sm transition">
+                <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="currentColor"><path fill-rule="evenodd" d="M1.203 5.169L.784 8.94a2.305 2.305 0 0 0 4.353 1.286L5.5 9.5h3l.363.726a2.305 2.305 0 0 0 4.353-1.286l-.42-3.771A3 3 0 0 0 9.816 2.5h-5.63a3 3 0 0 0-2.982 2.669m3.172-.794c.345 0 .625.28.625.625v.542h.542a.625.625 0 1 1 0 1.25H5v.541a.625.625 0 1 1-1.25 0v-.541h-.542a.625.625 0 1 1 0-1.25h.542V5c0-.345.28-.625.625-.625m4.89 3.042a.625.625 0 1 0 0-1.25a.625.625 0 0 0 0 1.25m1.876-2.175a.625.625 0 1 1-1.25 0a.625.625 0 0 1 1.25 0" clip-rule="evenodd"/></svg>
+                Style Control
+                <svg class="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02z" clip-rule="evenodd"/></svg>
+              </a>
+            </div>
+
+            <!-- Secondary links -->
+            <div class="mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-slate-500 dark:text-slate-400 animate-fade-up [animation-delay:300ms]">
+              <a href="https://github.com/Xiugapurin/Etude" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 hover:text-slate-900 dark:hover:text-slate-200 transition">
+                <svg class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+                GitHub
+              </a>
+              <a href="https://arxiv.org/abs/2509.16522" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 hover:text-slate-900 dark:hover:text-slate-200 transition">
+                <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" fill="currentColor"><path d="M62.258 8.006a22.22 22.22 0 0 0-20.929 13.448c-3.404 8.169-.96 13.898 6.506 24.59c10.935 16.09 122.178 149.673 122.178 149.673l-24.619 23.038c-20.74 20.735-21.632 48.566-2.34 67.852l28.663 27.3l-79.976 98.235c-6.21 6.614-10.053 18.221-6.585 26.552a22.7 22.7 0 0 0 21.21 14.06a20.23 20.23 0 0 0 15.249-7.536l95.122-88.437L363.33 496.39a27.14 27.14 0 0 0 18.418 7.61a25.3 25.3 0 0 0 7.335-1.108a27.66 27.66 0 0 0 18.4-18.99a25.6 25.6 0 0 0-6.481-23.69L272.219 305.195l23.062-21.443c17.198-15.504 17.29-42.455.197-58.076l-25.257-24.228L357.417 98.46l.115-.133l.103-.14c7.793-10.123 11.52-17.92 7.502-27.806a36.17 36.17 0 0 0-23.647-18.37a24 24 0 0 0-3.166-.212l-.006.018a28.52 28.52 0 0 0-18.252 8.123l-.203.166l-.19.173L218.6 151.925L79.261 18.253S70.995 8.213 62.258 8.006m276.06 51.214q1.115.004 2.22.148a29.3 29.3 0 0 1 17.719 13.81c2.246 5.523 1.554 10.01-6.506 20.484L264.861 196.3l-40.882-39.22l100.68-91.304a21.77 21.77 0 0 1 13.66-6.536zM175.077 201.127L395.19 464.872c4.32 5.408 7.02 10.818 5.18 16.914a20.25 20.25 0 0 1-13.463 14.037a17.6 17.6 0 0 1-5.17.784a19.8 19.8 0 0 1-13.293-5.56l-220.15-209.694c-17.317-17.316-14.698-40.33 2.158-57.186z"/></svg>
+                arXiv
+              </a>
+              <a href="./assets/paper.pdf" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 hover:text-slate-900 dark:hover:text-slate-200 transition">
+                <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M8.267 14.68c-.184 0-.308.018-.372.036v1.178c.076.018.171.023.302.023c.479 0 .774-.242.774-.651c0-.366-.254-.586-.704-.586m3.487.012c-.2 0-.33.018-.407.036v2.61c.077.018.201.018.313.018c.817.006 1.349-.444 1.349-1.396c.006-.83-.479-1.268-1.255-1.268"/><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM9.498 16.19c-.309.29-.765.42-1.296.42a2 2 0 0 1-.308-.018v1.426H7v-3.936A7.6 7.6 0 0 1 8.219 14c.557 0 .953.106 1.22.319c.254.202.426.533.426.923c-.001.392-.131.723-.367.948m3.807 1.355c-.42.349-1.059.515-1.84.515c-.468 0-.799-.03-1.024-.06v-3.917A8 8 0 0 1 11.66 14c.757 0 1.249.136 1.633.426c.415.308.675.799.675 1.504c0 .763-.279 1.29-.663 1.615M17 14.77h-1.532v.911H16.9v.734h-1.432v1.604h-.906V14.03H17zM14 9h-1V4l5 5z"/></svg>
+                PDF
+              </a>
+            </div>
+          </div>
+
+          <!-- Right: Visual panel -->
+          <div class="lg:col-span-5 relative animate-fade-up [animation-delay:320ms]">
+            <div class="relative mx-auto max-w-md lg:max-w-none">
+              <!-- Soft glow -->
+              <div class="absolute -inset-4 bg-gradient-to-br from-brand-500/20 via-fuchsia-500/10 to-accent-500/20 blur-2xl rounded-[2rem] pointer-events-none"></div>
+
+              <!-- Card -->
+              <div class="relative rounded-2xl border border-slate-200 dark:border-slate-800 bg-white/70 dark:bg-slate-900/70 backdrop-blur p-5 shadow-xl shadow-slate-900/5">
+                <!-- Header strip -->
+                <div class="flex items-center justify-between pb-3 border-b border-slate-200 dark:border-slate-800">
+                  <div class="flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full bg-red-400/80"></span>
+                    <span class="w-2 h-2 rounded-full bg-amber-400/80"></span>
+                    <span class="w-2 h-2 rounded-full bg-emerald-400/80"></span>
+                  </div>
+                  <span class="text-[10px] font-mono text-slate-500 dark:text-slate-400">etude • piano roll</span>
+                </div>
+
+                <!-- Piano roll preview (SVG) -->
+                <svg viewBox="0 0 320 170" class="mt-4 w-full h-auto" aria-hidden="true">
+                  <defs>
+                    <linearGradient id="eqGrad" x1="0" y1="1" x2="0" y2="0">
+                      <stop offset="0%" stop-color="#4f46e5" />
+                      <stop offset="100%" stop-color="#14b8a6" />
+                    </linearGradient>
+                    <linearGradient id="noteGrad" x1="0" y1="0" x2="1" y2="0">
+                      <stop offset="0%" stop-color="#6366f1" />
+                      <stop offset="100%" stop-color="#2dd4bf" />
+                    </linearGradient>
+                  </defs>
+
+                  <!-- faint horizontal grid -->
+                  <g stroke="currentColor" stroke-width="0.5" class="text-slate-200 dark:text-slate-700" opacity="0.8">
+                    <line x1="0" y1="22" x2="320" y2="22"/>
+                    <line x1="0" y1="44" x2="320" y2="44"/>
+                    <line x1="0" y1="66" x2="320" y2="66"/>
+                    <line x1="0" y1="88" x2="320" y2="88"/>
+                    <line x1="0" y1="110" x2="320" y2="110"/>
+                    <line x1="0" y1="132" x2="320" y2="132"/>
+                  </g>
+
+                  <!-- note rectangles -->
+                  <g>
+                    <rect x="12"  y="66" width="28" height="10" rx="3" fill="url(#noteGrad)" opacity="0.9"/>
+                    <rect x="44"  y="44" width="22" height="10" rx="3" fill="url(#noteGrad)" opacity="0.85"/>
+                    <rect x="70"  y="88" width="34" height="10" rx="3" fill="url(#noteGrad)" opacity="0.95"/>
+                    <rect x="108" y="22" width="18" height="10" rx="3" fill="url(#noteGrad)" opacity="0.8"/>
+                    <rect x="130" y="66" width="40" height="10" rx="3" fill="url(#noteGrad)" opacity="0.9"/>
+                    <rect x="174" y="110" width="26" height="10" rx="3" fill="url(#noteGrad)" opacity="0.85"/>
+                    <rect x="204" y="44" width="30" height="10" rx="3" fill="url(#noteGrad)" opacity="0.9"/>
+                    <rect x="238" y="88" width="22" height="10" rx="3" fill="url(#noteGrad)" opacity="0.85"/>
+                    <rect x="264" y="66" width="40" height="10" rx="3" fill="url(#noteGrad)" opacity="0.95"/>
+                  </g>
+
+                  <!-- playhead -->
+                  <line x1="150" y1="16" x2="150" y2="148" stroke="#4f46e5" stroke-width="1" stroke-dasharray="3 3" opacity="0.55"/>
+
+                  <!-- EQ bars at bottom -->
+                  <g transform="translate(0,170)">
+                    <rect class="eq-bar" x="12"  y="-28" width="4" height="24" rx="1.5" style="animation-delay:0s"/>
+                    <rect class="eq-bar" x="22"  y="-32" width="4" height="28" rx="1.5" style="animation-delay:0.1s"/>
+                    <rect class="eq-bar" x="32"  y="-24" width="4" height="20" rx="1.5" style="animation-delay:0.2s"/>
+                    <rect class="eq-bar" x="42"  y="-36" width="4" height="32" rx="1.5" style="animation-delay:0.05s"/>
+                    <rect class="eq-bar" x="52"  y="-20" width="4" height="16" rx="1.5" style="animation-delay:0.35s"/>
+                    <rect class="eq-bar" x="62"  y="-30" width="4" height="26" rx="1.5" style="animation-delay:0.15s"/>
+                    <rect class="eq-bar" x="72"  y="-26" width="4" height="22" rx="1.5" style="animation-delay:0.4s"/>
+                    <rect class="eq-bar" x="82"  y="-34" width="4" height="30" rx="1.5" style="animation-delay:0.25s"/>
+                  </g>
+                </svg>
+
+                <!-- Meta row -->
+                <div class="mt-4 flex items-center justify-between text-[11px] font-mono">
+                  <div class="flex items-center gap-3 text-slate-500 dark:text-slate-400">
+                    <span class="inline-flex items-center gap-1"><span class="w-2 h-2 rounded-sm bg-brand-500"></span> Polyphony</span>
+                    <span class="inline-flex items-center gap-1"><span class="w-2 h-2 rounded-sm bg-fuchsia-500"></span> Rhythm</span>
+                    <span class="inline-flex items-center gap-1"><span class="w-2 h-2 rounded-sm bg-accent-500"></span> Sustain</span>
+                  </div>
+                  <span class="text-brand-700 dark:text-brand-300">realtime</span>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        </div>
       </div>
     </header>
 
-    <nav class="bg-white border-b border-gray-200 py-6">
-      <div class="container mx-auto px-4 flex flex-wrap justify-center items-center gap-4">
-        <a
-          href="demo1.html"
-          class="inline-flex items-center bg-indigo-600 text-white font-semibold py-3 px-6 rounded-lg shadow-md hover:bg-indigo-700 transition-all transform hover:scale-105"
-        >
-          <svg class="w-6 h-6 mr-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-            <path
-              fill="currentColor"
-              d="m15.81 10l-2.5-5H14a.5.5 0 0 0 0-1h-.79a6.04 6.04 0 0 0-4.198-1.95L9 2a1 1 0 0 0-2 0v.05a6.17 6.17 0 0 0-4.247 1.947L2 4a.5.5 0 0 0 0 1h.69l-2.5 5H0c0 1.1 1.34 2 3 2s3-.9 3-2h-.19L3.26 4.91a.5.5 0 0 0 .159-.148A4.84 4.84 0 0 1 6.994 3.06L7 14H6v1H4v1h8v-1h-2v-1H9V3.06a4.7 4.7 0 0 1 3.524 1.693a.5.5 0 0 0 .193.186L10.19 10H10c0 1.1 1.34 2 3 2s3-.9 3-2zM5 10H1l2-3.94zm6 0l2-3.94L15 10z"
-            />
-          </svg>
-          Model Comparison
-        </a>
-
-        <a
-          href="demo2.html"
-          class="inline-flex items-center bg-indigo-600 text-white font-semibold py-3 px-6 rounded-lg shadow-md hover:bg-indigo-700 transition-all transform hover:scale-105"
-        >
-          <svg class="w-6 h-6 mr-3" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M1.203 5.169L.784 8.94a2.305 2.305 0 0 0 4.353 1.286L5.5 9.5h3l.363.726a2.305 2.305 0 0 0 4.353-1.286l-.42-3.771A3 3 0 0 0 9.816 2.5h-5.63a3 3 0 0 0-2.982 2.669m3.172-.794c.345 0 .625.28.625.625v.542h.542a.625.625 0 1 1 0 1.25H5v.541a.625.625 0 1 1-1.25 0v-.541h-.542a.625.625 0 1 1 0-1.25h.542V5c0-.345.28-.625.625-.625m4.89 3.042a.625.625 0 1 0 0-1.25a.625.625 0 0 0 0 1.25m1.876-2.175a.625.625 0 1 1-1.25 0a.625.625 0 0 1 1.25 0"
-              clip-rule="evenodd"
-            />
-          </svg>
-          Style Control
-        </a>
-
-        <a
-          href="https://github.com/Xiugapurin/Etude"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center bg-gray-800 text-white font-semibold py-3 px-6 rounded-lg shadow-md hover:bg-gray-900 transition-all transform hover:scale-105"
-        >
-          <svg class="w-6 h-6 mr-3" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-            <path
-              fill-rule="evenodd"
-              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
-            ></path>
-          </svg>
-          GitHub
-        </a>
-
-        <a
-          href="https://arxiv.org/abs/2509.16522"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center bg-teal-600 text-white font-semibold py-3 px-6 rounded-lg shadow-md hover:bg-teal-700 transition-all transform hover:scale-105"
-        >
-          <svg class="w-6 h-6 mr-3" xmlns="http://www.w3.org/2000/svg" width="448" height="512" viewBox="0 0 448 512">
-            <path
-              fill="currentColor"
-              d="M62.258 8.006a22.22 22.22 0 0 0-20.929 13.448c-3.404 8.169-.96 13.898 6.506 24.59c10.935 16.09 122.178 149.673 122.178 149.673l-24.619 23.038c-20.74 20.735-21.632 48.566-2.34 67.852l28.663 27.3l-79.976 98.235c-6.21 6.614-10.053 18.221-6.585 26.552a22.7 22.7 0 0 0 21.21 14.06a20.23 20.23 0 0 0 15.249-7.536l95.122-88.437L363.33 496.39a27.14 27.14 0 0 0 18.418 7.61a25.3 25.3 0 0 0 7.335-1.108a27.66 27.66 0 0 0 18.4-18.99a25.6 25.6 0 0 0-6.481-23.69L272.219 305.195l23.062-21.443c17.198-15.504 17.29-42.455.197-58.076l-25.257-24.228L357.417 98.46l.115-.133l.103-.14c7.793-10.123 11.52-17.92 7.502-27.806a36.17 36.17 0 0 0-23.647-18.37a24 24 0 0 0-3.166-.212l-.006.018a28.52 28.52 0 0 0-18.252 8.123l-.203.166l-.19.173L218.6 151.925L79.261 18.253S70.995 8.213 62.258 8.006m276.06 51.214q1.115.004 2.22.148a29.3 29.3 0 0 1 17.719 13.81c2.246 5.523 1.554 10.01-6.506 20.484L264.861 196.3l-40.882-39.22l100.68-91.304a21.77 21.77 0 0 1 13.66-6.536zM175.077 201.127L395.19 464.872c4.32 5.408 7.02 10.818 5.18 16.914a20.25 20.25 0 0 1-13.463 14.037a17.6 17.6 0 0 1-5.17.784a19.8 19.8 0 0 1-13.293-5.56l-220.15-209.694c-17.317-17.316-14.698-40.33 2.158-57.186z"
-            />
-          </svg>
-          Paper (arXiv)
-        </a>
-
-        <a
-          href="./assets/paper.pdf"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center bg-teal-600 text-white font-semibold py-3 px-6 rounded-lg shadow-md hover:bg-teal-700 transition-all transform hover:scale-105"
-        >
-          <svg class="w-6 h-6 mr-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
-            <path
-              fill="currentColor"
-              d="M8.267 14.68c-.184 0-.308.018-.372.036v1.178c.076.018.171.023.302.023c.479 0 .774-.242.774-.651c0-.366-.254-.586-.704-.586m3.487.012c-.2 0-.33.018-.407.036v2.61c.077.018.201.018.313.018c.817.006 1.349-.444 1.349-1.396c.006-.83-.479-1.268-1.255-1.268"
-            />
-            <path
-              fill="currentColor"
-              d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM9.498 16.19c-.309.29-.765.42-1.296.42a2 2 0 0 1-.308-.018v1.426H7v-3.936A7.6 7.6 0 0 1 8.219 14c.557 0 .953.106 1.22.319c.254.202.426.533.426.923c-.001.392-.131.723-.367.948m3.807 1.355c-.42.349-1.059.515-1.84.515c-.468 0-.799-.03-1.024-.06v-3.917A8 8 0 0 1 11.66 14c.757 0 1.249.136 1.633.426c.415.308.675.799.675 1.504c0 .763-.279 1.29-.663 1.615M17 14.77h-1.532v.911H16.9v.734h-1.432v1.604h-.906V14.03H17zM14 9h-1V4l5 5z"
-            />
-          </svg>
-          Paper (PDF)
-        </a>
-      </div>
-    </nav>
-
-    <main class="container mx-auto px-12 py-4 md:px-8 md:py-6">
-      <div class="bg-white p-6 rounded-xl shadow-md overflow-hidden">
-        <h2 class="text-2xl font-bold mb-4 text-gray-800 text-center">Automatic Piano Cover Generation Demo</h2>
-        <div class="w-full aspect-video">
-          <iframe
-            class="w-full h-full rounded-lg"
-            src="https://www.youtube.com/embed/Fu2e_Mgx5Bg"
-            title="YouTube video player for Etude Project"
-            frameborder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowfullscreen
-          >
-          </iframe>
+    <main class="container mx-auto px-4 pb-20">
+      <!-- Video -->
+      <section id="demos" class="relative -mt-10 md:-mt-14">
+        <div class="reveal rounded-2xl overflow-hidden border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-xl shadow-slate-900/5">
+          <div class="flex items-center justify-between px-5 py-3 border-b border-slate-200 dark:border-slate-800 bg-slate-50/80 dark:bg-slate-950/40">
+            <div class="flex items-center gap-2">
+              <span class="w-2.5 h-2.5 rounded-full bg-red-400/80"></span>
+              <span class="w-2.5 h-2.5 rounded-full bg-amber-400/80"></span>
+              <span class="w-2.5 h-2.5 rounded-full bg-emerald-400/80"></span>
+              <span class="ml-3 text-xs font-mono text-slate-500 dark:text-slate-400">etude/overview.mp4</span>
+            </div>
+            <span class="text-xs font-mono text-slate-500 dark:text-slate-400 hidden sm:inline">Automatic Piano Cover Demo</span>
+          </div>
+          <div class="aspect-video w-full bg-black">
+            <iframe
+              class="w-full h-full"
+              src="https://www.youtube.com/embed/Fu2e_Mgx5Bg"
+              title="YouTube video player for Etude Project"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            ></iframe>
+          </div>
         </div>
-      </div>
+      </section>
+
+      <!-- Feature cards -->
+      <section class="mt-16 md:mt-20">
+        <div class="reveal max-w-2xl">
+          <p class="text-xs font-mono uppercase tracking-wider text-brand-600 dark:text-brand-300">Pipeline</p>
+          <h2 class="mt-2 font-display text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">Three stages, end-to-end</h2>
+          <p class="mt-2 text-slate-600 dark:text-slate-300">Each stage has a focused responsibility, and together they turn a raw audio track into a stylized, expressive piano cover.</p>
+        </div>
+
+        <div class="mt-8 grid gap-5 md:grid-cols-3">
+          <div class="reveal group p-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 hover:border-brand-400/60 hover:shadow-md hover:-translate-y-0.5 transition">
+            <div class="inline-flex items-center gap-2">
+              <span class="font-mono text-xs px-2 py-1 rounded bg-brand-50 dark:bg-brand-600/10 text-brand-700 dark:text-brand-300">01 · Extract</span>
+            </div>
+            <h3 class="mt-4 font-display font-semibold text-lg">Audio → Symbolic</h3>
+            <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Lift musical content out of the source recording into a symbolic representation we can reason about.</p>
+          </div>
+          <div class="reveal group p-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 hover:border-brand-400/60 hover:shadow-md hover:-translate-y-0.5 transition">
+            <div class="inline-flex items-center gap-2">
+              <span class="font-mono text-xs px-2 py-1 rounded bg-fuchsia-50 dark:bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300">02 · strucTUralize</span>
+            </div>
+            <h3 class="mt-4 font-display font-semibold text-lg">Impose structure</h3>
+            <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Organize content into a structured form that captures phrasing, density, and rhythmic hierarchy.</p>
+          </div>
+          <div class="reveal group p-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 hover:border-brand-400/60 hover:shadow-md hover:-translate-y-0.5 transition">
+            <div class="inline-flex items-center gap-2">
+              <span class="font-mono text-xs px-2 py-1 rounded bg-teal-50 dark:bg-teal-500/10 text-teal-700 dark:text-teal-300">03 · DEcode</span>
+            </div>
+            <h3 class="mt-4 font-display font-semibold text-lg">Render a performance</h3>
+            <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Decode a stylized piano performance, steerable via high-level attributes like polyphony and rhythm intensity.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Demo entries -->
+      <section class="mt-16 md:mt-20 grid gap-5 md:grid-cols-2">
+        <a href="demo1.html" class="reveal group relative overflow-hidden p-8 rounded-2xl border border-slate-200 dark:border-slate-800 bg-gradient-to-br from-white to-slate-50 dark:from-slate-900 dark:to-slate-950 hover:border-brand-400/60 hover:shadow-xl transition">
+          <div class="absolute -right-10 -top-10 w-40 h-40 rounded-full bg-brand-500/10 blur-2xl group-hover:bg-brand-500/20 transition"></div>
+          <p class="text-xs font-mono uppercase tracking-wider text-brand-600 dark:text-brand-300">Demo 01</p>
+          <h3 class="mt-2 font-display text-2xl font-bold">Model Comparison</h3>
+          <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Listen side-by-side: Etude variants against baselines (Music2Midi, PiCoGen2, AMT-APC) across 100 songs in four genres.</p>
+          <span class="mt-6 inline-flex items-center gap-1.5 text-sm font-semibold text-brand-700 dark:text-brand-300">Open demo <svg class="w-4 h-4 transition-transform group-hover:translate-x-0.5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02z" clip-rule="evenodd"/></svg></span>
+        </a>
+        <a href="demo2.html" class="reveal group relative overflow-hidden p-8 rounded-2xl border border-slate-200 dark:border-slate-800 bg-gradient-to-br from-white to-slate-50 dark:from-slate-900 dark:to-slate-950 hover:border-accent-500/60 hover:shadow-xl transition">
+          <div class="absolute -right-10 -top-10 w-40 h-40 rounded-full bg-accent-500/10 blur-2xl group-hover:bg-accent-500/25 transition"></div>
+          <p class="text-xs font-mono uppercase tracking-wider text-accent-600 dark:text-accent-500">Demo 02</p>
+          <h3 class="mt-2 font-display text-2xl font-bold">Interactive Style Control</h3>
+          <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Move the sliders — polyphony, rhythm intensity, note sustain — and hear how Etude's output bends to your taste in real time.</p>
+          <span class="mt-6 inline-flex items-center gap-1.5 text-sm font-semibold text-accent-600 dark:text-accent-500">Try it live <svg class="w-4 h-4 transition-transform group-hover:translate-x-0.5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02z" clip-rule="evenodd"/></svg></span>
+        </a>
+      </section>
+
+      <!-- Resources + Cite -->
+      <section id="resources" class="mt-16 md:mt-20 grid gap-5 lg:grid-cols-5">
+        <div class="reveal lg:col-span-2 p-6 rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+          <p class="text-xs font-mono uppercase tracking-wider text-slate-500">Resources</p>
+          <h3 class="mt-2 font-display text-xl font-bold">Get the paper & code</h3>
+          <ul class="mt-4 space-y-2 text-sm">
+            <li><a class="text-brand-700 dark:text-brand-300 hover:underline" href="https://arxiv.org/abs/2509.16522" target="_blank" rel="noopener noreferrer">arXiv:2509.16522</a></li>
+            <li><a class="text-brand-700 dark:text-brand-300 hover:underline" href="./assets/paper.pdf" target="_blank" rel="noopener noreferrer">Paper (PDF)</a></li>
+            <li><a class="text-brand-700 dark:text-brand-300 hover:underline" href="https://github.com/Xiugapurin/Etude" target="_blank" rel="noopener noreferrer">github.com/Xiugapurin/Etude</a></li>
+          </ul>
+        </div>
+        <div id="cite" class="reveal lg:col-span-3 p-6 rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-900 text-slate-100 relative">
+          <div class="flex items-center justify-between">
+            <p class="text-xs font-mono uppercase tracking-wider text-slate-400">BibTeX</p>
+            <button id="copy-bibtex" type="button" class="copy-btn inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md bg-white/10 hover:bg-white/20 text-slate-100 transition">
+              <svg class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor"><path d="M8 2a2 2 0 0 0-2 2v1H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-1V4a2 2 0 0 0-2-2zm0 2h4v2H8zM5 7h10v9H5z"/></svg>
+              <span id="copy-label">Copy</span>
+            </button>
+          </div>
+          <pre class="bibtex mt-3 whitespace-pre-wrap break-words text-slate-100/90"><code id="bibtex">@article{chen2025etude,
+  title   = {Etude: Piano Cover Generation with a Three-Stage Approach-Extract, strucTUralize, and DEcode},
+  author  = {Chen, Tse-Yang and Joung, Yuh-Jzer},
+  journal = {arXiv preprint arXiv:2509.16522},
+  year    = {2025}
+}</code></pre>
+        </div>
+      </section>
     </main>
+
+    <footer class="border-t border-slate-200 dark:border-slate-800">
+      <div class="container mx-auto px-4 py-8 text-sm text-slate-500 dark:text-slate-400 flex flex-col md:flex-row items-center gap-2 justify-between">
+        <p>© 2025 Etude Project.</p>
+        <p class="font-mono text-xs">Extract · strucTUralize · DEcode</p>
+      </div>
+    </footer>
+
+    <script>
+      // Theme toggle
+      document.getElementById("theme-toggle").addEventListener("click", () => {
+        const root = document.documentElement;
+        root.classList.toggle("dark");
+        localStorage.setItem("etude-theme", root.classList.contains("dark") ? "dark" : "light");
+      });
+
+      // Reveal on scroll
+      const io = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((e) => {
+            if (e.isIntersecting) {
+              e.target.classList.add("in");
+              io.unobserve(e.target);
+            }
+          });
+        },
+        { threshold: 0.12 }
+      );
+      document.querySelectorAll(".reveal").forEach((el) => io.observe(el));
+
+      // Copy BibTeX
+      const copyBtn = document.getElementById("copy-bibtex");
+      const copyLabel = document.getElementById("copy-label");
+      copyBtn?.addEventListener("click", async () => {
+        const text = document.getElementById("bibtex").innerText;
+        try {
+          await navigator.clipboard.writeText(text);
+          copyLabel.textContent = "Copied!";
+          setTimeout(() => (copyLabel.textContent = "Copy"), 1500);
+        } catch {
+          copyLabel.textContent = "Press ⌘C";
+        }
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Modernizes the GitHub Pages demo site (`docs/`) with a cohesive design system and reworks the two demo pages into keyboard-driven player UIs that fit within a single viewport.

### Design system (shared)
- Fonts: Space Grotesk (display) + Inter (body) + JetBrains Mono (code/labels)
- Palette: restrained indigo (brand) → teal (accent) gradient
- Light theme by default; dark mode is opt-in via the top-right toggle and persisted to localStorage
- BibTeX entry corrected to match published arXiv metadata

### index.html — Hero redesign
- Two-column layout: copy + CTAs on the left, animated piano-roll preview card on the right
- Pipeline chips (`Extract → strucTUralize → DEcode`) promoted as a standalone visual element
- CTA hierarchy: two primary buttons (Model Comparison, Style Control); GitHub / arXiv / PDF demoted to text links
- Aurora + dot-grid backdrop with subtle pan animation

### demo1.html — Model Comparison
- Single-song player UI; no vertical scroll on desktop
- Left/right arrow buttons **or** keyboard to switch songs (carries over between categories)
- Category tabs with `[` / `]` shortcuts
- Keyboard: `←` `→` song, `[` `]` category, `Space` play/pause, `1`–`7` track
- Tracks tagged as `Ours` / `Ref` / `Baseline`; playing track highlighted
- Progress bar shows position within the current category

### demo2.html — Style Control
- Single-viewport layout; sliders auto-distribute vertically
- Each attribute now has a description (sourced from `etude/data/dataset.py` authoritative comments)
- Tab switch between **Piano Roll** and **Origin Video** (MIDI player hides when video is active; iframe src is only set on activation, cleared on switch back to avoid background audio)
- Removed the Current config block per request
- Custom gradient range sliders with clickable step pills
- Keyboard: `Space` play/pause, `R` reset

## Test plan
- Open `docs/index.html`, `docs/demo1.html`, `docs/demo2.html` on GitHub Pages preview or locally
- Verify no vertical scroll on desktop for demo1 / demo2
- demo1: arrow-key song navigation, `[` / `]` category switching, `1`–`7` track selection, `Space` play/pause
- demo2: slider interaction updates MIDI immediately; tab switch stops MIDI and loads video; switching back clears the video iframe
- Toggle dark mode from top-right; refresh to confirm preference is persisted
- Copy BibTeX from index footer and verify it matches the arXiv entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)